### PR TITLE
return slurm version as tuple

### DIFF
--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -3,6 +3,8 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+from typing import Tuple
+
 from clusterscope.cluster_info import ClusterInfo
 
 cluster_info = ClusterInfo()
@@ -12,5 +14,7 @@ def cluster() -> str:
     return cluster_info.get_cluster_name()
 
 
-def slurm_version() -> str:
-    return cluster_info.get_slurm_version()
+def slurm_version() -> Tuple[int, ...]:
+    slurm_version = cluster_info.get_slurm_version()
+    version = tuple(int(v) for v in slurm_version.split("."))
+    return version


### PR DESCRIPTION
## Summary

clients are using this as tuple, moving to tuple before returning to client

## Test Plan

```
$ cscope info
Cluster Name: <name>
Slurm Version: 24.11.4
```
