### PR TITLE
add local node interface so clusterscope works outside slurm clusters [1/n]

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -9,7 +9,7 @@ import json
 import sys
 from typing import Any, Dict
 
-from clusterscope.cluster_info import ClusterInfo
+from clusterscope.cluster_info import UnifiedInfo
 
 
 def format_dict(data: Dict[str, Any]) -> str:
@@ -57,16 +57,16 @@ def main():
         return 1
 
     try:
-        cluster_info = ClusterInfo()
+        unified_info = UnifiedInfo()
 
         if args.command == "info":
-            cluster_name = cluster_info.get_cluster_name()
-            slurm_version = cluster_info.get_slurm_version()
+            cluster_name = unified_info.get_cluster_name()
+            slurm_version = unified_info.get_slurm_version()
             print(f"Cluster Name: {cluster_name}")
             print(f"Slurm Version: {slurm_version}")
 
         elif args.command == "cpus":
-            cpus_per_node = cluster_info.get_cpus_per_node()
+            cpus_per_node = unified_info.get_cpus_per_node()
             print("CPU counts per node:")
             print(format_dict(cpus_per_node))
 
@@ -74,24 +74,24 @@ def main():
             if args.counts:
                 print("TODO: counts by type:")
             else:
-                generations = cluster_info.get_gpu_generation_and_count()
+                generations = unified_info.get_gpu_generation_and_count()
                 print("GPU generations available:")
                 for gen in sorted(generations):
                     print(f"- {gen}")
 
         elif args.command == "check-gpu":
             gpu_type = args.gpu_type
-            has_gpu = cluster_info.has_gpu_type(gpu_type)
+            has_gpu = unified_info.has_gpu_type(gpu_type)
             if has_gpu:
                 print(f"GPU type {gpu_type} is available in the cluster.")
             else:
                 print(f"GPU type {gpu_type} is NOT available in the cluster.")
 
         elif args.command == "aws":
-            is_aws = cluster_info.is_aws_cluster()
+            is_aws = unified_info.is_aws_cluster()
             if is_aws:
                 print("This is an AWS cluster.")
-                nccl_settings = cluster_info.get_aws_nccl_settings()
+                nccl_settings = unified_info.get_aws_nccl_settings()
                 print("\nRecommended NCCL settings:")
                 print(format_dict(nccl_settings))
             else:

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -103,7 +103,7 @@ class LocalNodeInfo:
                 timeout=timeout,
             )
 
-            gpu_info = defaultdict(int)
+            gpu_info: Dict[str, int] = defaultdict(int)
             for line in result.strip().split("\n"):
                 parts = line.split()
                 gpu_gen = parts[1]
@@ -248,7 +248,7 @@ class SlurmClusterInfo:
             )
 
             # Parse output
-            gpu_info = {}
+            gpu_info: Dict[str, int] = {}
             logging.debug("Parsing node information...")
             for line in result.stdout.splitlines():
                 parts = line.split(":")

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -7,10 +7,11 @@ import logging
 import re
 import shutil
 import subprocess
-from typing import Dict, Set
 from collections import defaultdict
+from typing import Dict, Set
 
 from clusterscope.cache import fs_cache
+
 
 class UnifiedInfo:
     def __init__(self):
@@ -25,9 +26,9 @@ class UnifiedInfo:
         Returns:
             str: The name of the Slurm cluster.
         """
-        if self.slurm_cluster_info.is_slurm_cluster()
+        if self.slurm_cluster_info.is_slurm_cluster:
             return self.slurm_cluster_info.get_cluster_name()
-        return 'local-node'
+        return "local-node"
 
     def get_slurm_version(self) -> str:
         """Get the slurm version. Returns `0` if not a Slurm cluster.
@@ -35,30 +36,30 @@ class UnifiedInfo:
         Returns:
             str: Slurm version as a string: "24.11.4"
         """
-        if self.slurm_cluster_info.is_slurm_cluster()
+        if self.slurm_cluster_info.is_slurm_cluster:
             return self.slurm_cluster_info.get_slurm_version()
-        return '0'
-    
+        return "0"
+
     def get_cpus_per_node(self) -> int:
         """Get the number of CPUs for each node in the cluster. Returns 0 if not a Slurm cluster.
 
         Returns:
             int: The number of CPUs per node, assuming all nodes have the same CPU count.
         """
-        if self.slurm_cluster_info.is_slurm_cluster()
+        if self.slurm_cluster_info.is_slurm_cluster:
             return self.slurm_cluster_info.get_cpus_per_node()
         return self.local_node_info.get_cpu_count()
-    
+
     def get_gpu_generation_and_count(self) -> Dict[str, int]:
         """Get the number of GPUs on the slurm cluster node.
 
         Returns:
             dict: A dictionary with GPU generation as keys and counts as values.
         """
-        if self.slurm_cluster_info.is_slurm_cluster()
+        if self.slurm_cluster_info.is_slurm_cluster:
             return self.slurm_cluster_info.get_gpu_generation_and_count()
         return self.local_node_info.get_gpu_generation_and_count()
-    
+
 
 class LocalNodeInfo:
     """A class to provide information about the local node.
@@ -66,7 +67,7 @@ class LocalNodeInfo:
     This class offers methods to query various aspects of the local node,
     such as CPU and GPU information.
     """
-    
+
     @fs_cache(var_name="LOCAL_NODE_CPU_COUNT")
     def get_cpu_count(self, timeout: int = 60) -> int:
         """Get the number of CPUs on the local node.
@@ -85,7 +86,7 @@ class LocalNodeInfo:
             return int(result.strip())
         except (subprocess.SubprocessError, FileNotFoundError) as e:
             raise RuntimeError(f"Failed to get CPU information: {str(e)}")
-    
+
     def get_gpu_generation_and_count(self, timeout: int = 60) -> Dict[str, int]:
         """Get the number of GPUs on the local node.
 
@@ -124,9 +125,9 @@ class SlurmClusterInfo:
         """Initialize the Cluster instance."""
         self.is_slurm_cluster = False
         if shutil.which("sinfo") is not None:
-            self.is_slurm_cluster = self._verify_slurm_available()
+            self.is_slurm_cluster = self.verify_slurm_available()
 
-    def _verify_slurm_available(self) -> bool:
+    def verify_slurm_available(self) -> bool:
         """Verify that Slurm commands are available on the system."""
         try:
             subprocess.run(
@@ -332,6 +333,7 @@ class SlurmClusterInfo:
             raise RuntimeError("Could not find MaxJobTime in scontrol output")
         except (subprocess.SubprocessError, FileNotFoundError) as e:
             raise RuntimeError(f"Failed to get maximum job lifetime: {str(e)}")
+
 
 class AWSClusterInfo:
     def is_aws_cluster(self) -> bool:

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -26,7 +26,7 @@ class UnifiedInfo:
         Returns:
             str: The name of the Slurm cluster.
         """
-        if self.slurm_cluster_info.is_slurm_cluster:
+        if self.is_slurm_cluster:
             return self.slurm_cluster_info.get_cluster_name()
         return "local-node"
 
@@ -285,8 +285,8 @@ class SlurmClusterInfo:
             for line in result.stdout.split("\n"):
                 if line.strip():
                     parts = line.split(":")
-                    if len(parts) >= 2 and not parts[1].isdigit():
-                        gpu_generations.add(parts[1].upper())
+                    if len(parts) >= 2 and not parts[2].isdigit():
+                        gpu_generations.add(parts[2].upper())
 
             if not gpu_generations:
                 return set()  # Return empty set if no GPUs found

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 from collections import defaultdict
+from functools import lru_cache
 from typing import Dict, Set
 
 from clusterscope.cache import fs_cache
@@ -71,8 +72,9 @@ class LocalNodeInfo:
     such as CPU and GPU information.
     """
 
+    @lru_cache(maxsize=1)
     def has_nvidia_gpus(self) -> bool:
-        """Verify that Slurm commands are available on the system."""
+        """Verify that nvidia GPU is available on the system."""
         try:
             subprocess.run(
                 ["nvidia-smi"],
@@ -112,6 +114,7 @@ class LocalNodeInfo:
         Raises:
             RuntimeError: If unable to retrieve GPU information.
         """
+        assert self.has_nvidia_gpus() is True
         try:
             result = subprocess.check_output(
                 ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"],
@@ -143,6 +146,7 @@ class SlurmClusterInfo:
         if shutil.which("sinfo") is not None:
             self.is_slurm_cluster = self.verify_slurm_available()
 
+    @lru_cache(maxsize=1)
     def verify_slurm_available(self) -> bool:
         """Verify that Slurm commands are available on the system."""
         try:

--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -5,16 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Tuple
 
-from clusterscope.cluster_info import ClusterInfo
+from clusterscope.cluster_info import UnifiedInfo
 
-cluster_info = ClusterInfo()
+unified_info = UnifiedInfo()
 
 
 def cluster() -> str:
-    return cluster_info.get_cluster_name()
+    return unified_info.get_cluster_name()
 
 
 def slurm_version() -> Tuple[int, ...]:
-    slurm_version = cluster_info.get_slurm_version()
+    slurm_version = unified_info.get_slurm_version()
     version = tuple(int(v) for v in slurm_version.split("."))
     return version

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -16,8 +16,13 @@ class TestUnifiedInfo(unittest.TestCase):
     def test_get_cluster_name(self):
         unified_info = UnifiedInfo()
         unified_info.is_slurm_cluster = False
-        assert unified_info.is_slurm_cluster is False
         self.assertEqual(unified_info.get_cluster_name(), "local-node")
+
+    def test_get_gpu_generation_and_count(self):
+        unified_info = UnifiedInfo()
+        unified_info.is_slurm_cluster = False
+        unified_info.has_nvidia_gpus = False
+        self.assertEqual(unified_info.get_gpu_generation_and_count(), {})
 
 
 class TestSlurmClusterInfo(unittest.TestCase):

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -8,14 +8,14 @@ import subprocess
 import unittest
 from unittest.mock import MagicMock, patch
 
-from clusterscope.cluster_info import AWSClusterInfo, ClusterInfo
+from clusterscope.cluster_info import AWSClusterInfo, SlurmClusterInfo
 
 
-class TestClusterInfo(unittest.TestCase):
+class TestSlurmClusterInfo(unittest.TestCase):
     def setUp(self):
         if shutil.which("sinfo") is None:
             self.skipTest("Machine does not have slurm")
-        self.cluster_info = ClusterInfo()
+        self.cluster_info = SlurmClusterInfo()
 
     @patch("subprocess.run")
     def test_get_cluster_name(self, mock_run):
@@ -71,7 +71,7 @@ class TestClusterInfo(unittest.TestCase):
         )
 
         # Create an instance of the class
-        cluster_info = ClusterInfo()
+        cluster_info = SlurmClusterInfo()
 
         # Call the method and check the result
         result = cluster_info.get_gpu_generations()
@@ -86,7 +86,7 @@ class TestClusterInfo(unittest.TestCase):
         )
 
         # Create an instance of the class
-        cluster_info = ClusterInfo()
+        cluster_info = SlurmClusterInfo()
 
         # Call the method and check the result
         result = cluster_info.get_gpu_generations()
@@ -95,7 +95,7 @@ class TestClusterInfo(unittest.TestCase):
     @patch("subprocess.run")
     def test_get_gpu_generations_error(self, mock_run):
         # Create an instance of the class
-        cluster_info = ClusterInfo()
+        cluster_info = SlurmClusterInfo()
 
         # Mock failed command
         mock_run.side_effect = subprocess.SubprocessError()
@@ -107,13 +107,13 @@ class TestClusterInfo(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             cluster_info.get_gpu_generations()
 
-    @patch("clusterscope.cluster_info.ClusterInfo.get_gpu_generation_and_count")
+    @patch("clusterscope.cluster_info.SlurmClusterInfo.get_gpu_generation_and_count")
     def test_has_gpu_type_true(self, mock_get_gpu_generation_and_count):
         # Set up the mock to return a dictionary with the GPU type we're looking for
         mock_get_gpu_generation_and_count.return_value = {"A100": 4, "V100": 2}
 
         # Create an instance of the class containing the has_gpu_type method
-        gpu_manager = ClusterInfo()
+        gpu_manager = SlurmClusterInfo()
 
         result = gpu_manager.has_gpu_type("A100")
         self.assertTrue(result)

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -8,7 +8,16 @@ import subprocess
 import unittest
 from unittest.mock import MagicMock, patch
 
-from clusterscope.cluster_info import AWSClusterInfo, SlurmClusterInfo
+from clusterscope.cluster_info import AWSClusterInfo, SlurmClusterInfo, UnifiedInfo
+
+
+class TestUnifiedInfo(unittest.TestCase):
+
+    def test_get_cluster_name(self):
+        unified_info = UnifiedInfo()
+        unified_info.is_slurm_cluster = False
+        assert unified_info.is_slurm_cluster is False
+        self.assertEqual(unified_info.get_cluster_name(), "local-node")
 
 
 class TestSlurmClusterInfo(unittest.TestCase):
@@ -24,16 +33,6 @@ class TestSlurmClusterInfo(unittest.TestCase):
             stdout="ClusterName=test_cluster\nOther=value", returncode=0
         )
         self.assertEqual(self.cluster_info.get_cluster_name(), "test_cluster")
-
-    @patch("subprocess.run")
-    def test_get_cluster_name_error(self, mock_run):
-        # Mock failed command
-        mock_run.side_effect = subprocess.SubprocessError()
-        with self.assertRaises(RuntimeError):
-            self.cluster_info.get_cluster_name()
-        mock_run.side_effect = FileNotFoundError()
-        with self.assertRaises(RuntimeError):
-            self.cluster_info.get_cluster_name()
 
     @patch("subprocess.run")
     def test_get_max_job_lifetime(self, mock_run):


### PR DESCRIPTION
## Summary

adding a local interface for when running clusterscope outside of a slurm cluster. also adding a unified interface that routes to slurm information or local node queries based on whether it's inside a slurm cluster. 

this enables researcher code to use the same method for clusterscope for local development and running jobs inside a cluster

## Test Plan

```
(clusterscope) luccab@luccab-gpu-login-0:/storage/home/luccab/clusterscope$ python -m unittest discover -s tests
...........
----------------------------------------------------------------------
Ran 11 tests in 0.034s

OK
```