### PR TITLE
add slurm/local memory and cpus

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -68,7 +68,12 @@ def main():
         elif args.command == "cpus":
             cpus_per_node = unified_info.get_cpus_per_node()
             print("CPU counts per node:")
-            print(format_dict(cpus_per_node))
+            print(cpus_per_node)
+
+        elif args.command == "mem":
+            mem_per_node = unified_info.get_mem_per_node()
+            print("Mem per node:")
+            print(mem_per_node)
 
         elif args.command == "gpus":
             if args.counts:

--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -18,3 +18,11 @@ def slurm_version() -> Tuple[int, ...]:
     slurm_version = unified_info.get_slurm_version()
     version = tuple(int(v) for v in slurm_version.split("."))
     return version
+
+
+def cpus() -> int:
+    return unified_info.get_cpus_per_node()
+
+
+def mem() -> int:
+    return unified_info.get_mem_per_node()


### PR DESCRIPTION
## Summary

exposing cpu and memory from clusterscope. 

queries slurm for slurm clusters, if running locally it assumes `nproc` and `free` are available.

## Test Plan

```
(clusterscope) luccab@luccab-gpu-login-0:/storage/home/luccab/clusterscope$ python -m unittest discover -s tests
...............
----------------------------------------------------------------------
Ran 15 tests in 0.040s

OK
```