### PR TITLE
mypy on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,9 @@ repos:
   hooks:
     - id: black
       args: [--line-length=88]
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.11.2
+  hooks:
+    - id: mypy
+      files: ^(clusterscope)/
+      args: ["--install-types", "--non-interactive"]


### PR DESCRIPTION
## Summary

adding mypy to pre-commit checks

## Test Plan
mypy now runs on pre-commit:
```
$ git commit -m 'mypy on pre-commit'
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
flake8...............................................(no files to check)Skipped
Format files with µfmt...............................(no files to check)Skipped
black................................................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
[mypy 35c2bf7] mypy on pre-commit
 1 file changed, 6 insertions(+)
```