### PR TITLE
exposing gpu count and type for local node

### DIFF
--- a/clusterscope/__init__.py
+++ b/clusterscope/__init__.py
@@ -5,6 +5,18 @@
 # LICENSE file in the root directory of this source tree.
 __version__ = "0.0.0"
 
-from clusterscope.lib import cluster, cpus, mem, slurm_version
+from clusterscope.lib import (
+    cluster,
+    cpus,
+    local_node_gpu_generation_and_count,
+    mem,
+    slurm_version,
+)
 
-__all__ = ["cluster", "slurm_version", "cpus", "mem"]
+__all__ = [
+    "cluster",
+    "slurm_version",
+    "cpus",
+    "mem",
+    "local_node_gpu_generation_and_count",
+]

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -220,7 +220,7 @@ class LocalNodeInfo:
         Raises:
             RuntimeError: If unable to retrieve GPU information.
         """
-        assert self.has_nvidia_gpus() is True
+        assert self.has_nvidia_gpus() is True, "No nvidia GPUs found"
         try:
             result = subprocess.check_output(
                 ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"],

--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -3,11 +3,12 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Literal, Tuple
+from typing import Dict, Literal, Tuple
 
-from clusterscope.cluster_info import UnifiedInfo
+from clusterscope.cluster_info import LocalNodeInfo, UnifiedInfo
 
 unified_info = UnifiedInfo()
+local_info = LocalNodeInfo()
 
 
 def cluster() -> str:
@@ -41,3 +42,8 @@ def mem(
             f"{to_unit} is not a supported unit. Currently supported units: MB, GB"
         )
     return mem
+
+
+def local_node_gpu_generation_and_count() -> Dict[str, int]:
+    """Get the GPU generation and count for the local node."""
+    return local_info.get_gpu_generation_and_count()


### PR DESCRIPTION
## Summary

exposing `get_gpu_generation_and_count` for localhost

## Test Plan

```shell
$ python
Python 3.10.12 (main, Jul  5 2023, 18:54:27) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import clusterscope
>>> clusterscope.local_node_gpu_generation_and_count()
defaultdict(<class 'int'>, {'GV100': 2})
>>> 
```
