### PR TITLE
add check for nvidia-smi failure if no GPUs detected, i.e. submit host

### DIFF
--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -206,7 +206,7 @@ class LocalNodeInfo:
                 check=True,
             )
             return True
-        except FileNotFoundError:
+        except (FileNotFoundError, subprocess.CalledProcessError):
             return False
 
     @fs_cache(var_name="LOCAL_NODE_CPU_COUNT")


### PR DESCRIPTION
## Summary

Unable to import clusterscope on cluster submit host where nivida-smi executable exists but returns non zero exit code as no GPUs detected.

## Test Plan

import clusterscope (previously failed, now works)
