### PR TITLE
fix `cscope aws` not working when calling via the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,3 +141,67 @@ jobs:
 
       - name: Run tests
         run: python -m unittest discover -s tests
+
+cli-tests:
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+  steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+        cache-dependency-glob: "requirements.txt"
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install requirements
+      run: |
+        make install-requirements
+        make install
+
+    - name: Test CLI help command
+      run: |
+        cscope --help
+
+    - name: Test CLI info command (expect failure in CI)
+      run: |
+        cscope info || echo "Expected failure - no Slurm cluster in CI"
+
+    - name: Test CLI cpus command (expect failure in CI)
+      run: |
+        cscope cpus || echo "Expected failure - no Slurm cluster in CI"
+
+    - name: Test CLI mem command (expect failure in CI)
+      run: |
+        cscope mem || echo "Expected failure - no Slurm cluster in CI"
+
+    - name: Test CLI gpus command (expect failure in CI)
+      run: |
+        cscope gpus || echo "Expected failure - no Slurm cluster in CI"
+
+    - name: Test CLI gpus with flags (expect failure in CI)
+      run: |
+        cscope gpus --generations || echo "Expected failure - no Slurm cluster in CI"
+        cscope gpus --counts || echo "Expected failure - no Slurm cluster in CI"
+        cscope gpus --vendor || echo "Expected failure - no Slurm cluster in CI"
+
+    - name: Test CLI check-gpu command (expect failure in CI)
+      run: |
+        cscope check-gpu A100 || echo "Expected failure - no Slurm cluster in CI"
+        cscope check-gpu MI300X || echo "Expected failure - no Slurm cluster in CI"
+
+    - name: Test CLI aws command (expect failure in CI)
+      run: |
+        cscope aws || echo "Expected failure - no Slurm cluster in CI"
+
+    - name: Test CLI with invalid command
+      run: |
+        cscope invalid-command && exit 1 || echo "Expected failure for invalid command"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,8 @@ jobs:
         run: python -m unittest discover -s tests
 
   cli-tests:
+    env:
+      UV_SYSTEM_PYTHON: 1
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,66 +142,66 @@ jobs:
       - name: Run tests
         run: python -m unittest discover -s tests
 
-cli-tests:
-  runs-on: ubuntu-latest
-  strategy:
-    matrix:
-      python-version: ["3.9", "3.10", "3.11", "3.12"]
+  cli-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
-  steps:
-    - uses: actions/checkout@v4
+    steps:
+      - uses: actions/checkout@v4
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      with:
-        enable-cache: true
-        cache-dependency-glob: "requirements.txt"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "requirements.txt"
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install requirements
-      run: |
-        make install-requirements
-        make install
+      - name: Install requirements
+        run: |
+          make install-requirements
+          make install
 
-    - name: Test CLI help command
-      run: |
-        cscope --help
+      - name: Test CLI help command
+        run: |
+          cscope --help
 
-    - name: Test CLI info command (expect failure in CI)
-      run: |
-        cscope info || echo "Expected failure - no Slurm cluster in CI"
+      - name: Test CLI info command (expect failure in CI)
+        run: |
+          cscope info || echo "Expected failure - no Slurm cluster in CI"
 
-    - name: Test CLI cpus command (expect failure in CI)
-      run: |
-        cscope cpus || echo "Expected failure - no Slurm cluster in CI"
+      - name: Test CLI cpus command (expect failure in CI)
+        run: |
+          cscope cpus || echo "Expected failure - no Slurm cluster in CI"
 
-    - name: Test CLI mem command (expect failure in CI)
-      run: |
-        cscope mem || echo "Expected failure - no Slurm cluster in CI"
+      - name: Test CLI mem command (expect failure in CI)
+        run: |
+          cscope mem || echo "Expected failure - no Slurm cluster in CI"
 
-    - name: Test CLI gpus command (expect failure in CI)
-      run: |
-        cscope gpus || echo "Expected failure - no Slurm cluster in CI"
+      - name: Test CLI gpus command (expect failure in CI)
+        run: |
+          cscope gpus || echo "Expected failure - no Slurm cluster in CI"
 
-    - name: Test CLI gpus with flags (expect failure in CI)
-      run: |
-        cscope gpus --generations || echo "Expected failure - no Slurm cluster in CI"
-        cscope gpus --counts || echo "Expected failure - no Slurm cluster in CI"
-        cscope gpus --vendor || echo "Expected failure - no Slurm cluster in CI"
+      - name: Test CLI gpus with flags (expect failure in CI)
+        run: |
+          cscope gpus --generations || echo "Expected failure - no Slurm cluster in CI"
+          cscope gpus --counts || echo "Expected failure - no Slurm cluster in CI"
+          cscope gpus --vendor || echo "Expected failure - no Slurm cluster in CI"
 
-    - name: Test CLI check-gpu command (expect failure in CI)
-      run: |
-        cscope check-gpu A100 || echo "Expected failure - no Slurm cluster in CI"
-        cscope check-gpu MI300X || echo "Expected failure - no Slurm cluster in CI"
+      - name: Test CLI check-gpu command (expect failure in CI)
+        run: |
+          cscope check-gpu A100 || echo "Expected failure - no Slurm cluster in CI"
+          cscope check-gpu MI300X || echo "Expected failure - no Slurm cluster in CI"
 
-    - name: Test CLI aws command (expect failure in CI)
-      run: |
-        cscope aws || echo "Expected failure - no Slurm cluster in CI"
+      - name: Test CLI aws command (expect failure in CI)
+        run: |
+          cscope aws || echo "Expected failure - no Slurm cluster in CI"
 
-    - name: Test CLI with invalid command
-      run: |
-        cscope invalid-command && exit 1 || echo "Expected failure for invalid command"
+      - name: Test CLI with invalid command
+        run: |
+          cscope invalid-command && exit 1 || echo "Expected failure for invalid command"

--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -9,7 +9,7 @@ import json
 import sys
 from typing import Any, Dict
 
-from clusterscope.cluster_info import UnifiedInfo
+from clusterscope.cluster_info import AWSClusterInfo, UnifiedInfo
 
 
 def format_dict(data: Dict[str, Any]) -> str:
@@ -66,6 +66,7 @@ def main():
 
     try:
         unified_info = UnifiedInfo()
+        aws_cluster_info = AWSClusterInfo()
 
         if args.command == "info":
             cluster_name = unified_info.get_cluster_name()
@@ -125,10 +126,10 @@ def main():
                 print(f"GPU type {gpu_type} is NOT available in the cluster.")
 
         elif args.command == "aws":
-            is_aws = unified_info.is_aws_cluster()
+            is_aws = aws_cluster_info.is_aws_cluster()
             if is_aws:
                 print("This is an AWS cluster.")
-                nccl_settings = unified_info.get_aws_nccl_settings()
+                nccl_settings = aws_cluster_info.get_aws_nccl_settings()
                 print("\nRecommended NCCL settings:")
                 print(format_dict(nccl_settings))
             else:


### PR DESCRIPTION
## Summary

fixing https://github.com/facebookresearch/clusterscope/issues/50

## Test Plan
show no error when running the cli:
```
$ cscope aws
This is NOT an AWS cluster.
```
