### PR TITLE
fixing `cscope check-gpu` for slurm clusters

### DIFF
--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -689,7 +689,7 @@ class SlurmClusterInfo:
             bool: True if the GPU type is available, False otherwise
         """
         gpu_counts = self.get_gpu_generation_and_count()
-        return gpu_type.upper() in gpu_counts
+        return gpu_type.upper() in [k.upper() for k in gpu_counts.keys()]
 
     def get_max_job_lifetime(self) -> str:
         """Get the maximum job lifetime specified in the Slurm configuration.


### PR DESCRIPTION
## Summary

fixing https://github.com/facebookresearch/clusterscope/issues/51

## Test Plan

observe cmd now succeeds:
```shell
$ sinfo -o %G
GRES
gpu:h100:7(S:0-1)
gpu:h100:8(S:0-1)
$ cscope check-gpu h100
GPU type h100 is available in the cluster.
```
