### PR TITLE
initializing job info only if `clusterscope.get_job()` gets called

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
         run: |
           python -c "import clusterscope; clusterscope.__version__"
 
+      - name: initialize clusterscope get_job
+        run: |
+          python -c "import clusterscope; clusterscope.get_job()"
+
   format:
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Read our contributing guide to learn about our development process, how to propo
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](https://code.fb.com/codeofconduct) so that you can understand what actions will and will not be tolerated.
 
-## Mantainers
+## Maintainers
 
 clusterscope is actively maintained by [Lucca Bertoncini](https://github.com/luccabb), and [Kalyan Saladi](https://github.com/skalyan).
 

--- a/clusterscope/__init__.py
+++ b/clusterscope/__init__.py
@@ -8,7 +8,7 @@ __version__ = "0.0.0"
 from clusterscope.lib import (
     cluster,
     cpus,
-    job,
+    get_job,
     local_node_gpu_generation_and_count,
     mem,
     slurm_version,
@@ -20,5 +20,5 @@ __all__ = [
     "cpus",
     "mem",
     "local_node_gpu_generation_and_count",
-    "job",
+    "get_job",
 ]

--- a/clusterscope/job_info.py
+++ b/clusterscope/job_info.py
@@ -38,25 +38,25 @@ class JobInfo:
     @lru_cache(maxsize=1)
     def get_global_rank(self) -> int:
         if self.is_slurm_job:
-            return int(os.environ.get("SLURM_PROCID", "0"))
+            return int(os.environ["SLURM_PROCID"])
         if self.is_torch_run:
-            return int(os.environ.get("RANK", "0"))
+            return int(os.environ["RANK"])
         return 0
 
     @lru_cache(maxsize=1)
     def get_local_rank(self) -> int:
         if self.is_slurm_job:
-            return int(os.environ.get("SLURM_LOCALID", "0"))
+            return int(os.environ["SLURM_LOCALID"])
         if self.is_torch_run:
-            return int(os.environ.get("LOCAL_RANK", "0"))
+            return int(os.environ["LOCAL_RANK"])
         return 0
 
     @lru_cache(maxsize=1)
     def get_world_size(self) -> int:
         if self.is_torch_run:
-            return int(os.environ.get("WORLD_SIZE", "1"))
+            return int(os.environ["WORLD_SIZE"])
         if self.is_slurm_job:
-            return int(os.environ.get("SLURM_NTASKS", "1"))
+            return int(os.environ["SLURM_NTASKS"])
         return 1
 
     @lru_cache(maxsize=1)
@@ -66,22 +66,17 @@ class JobInfo:
     @lru_cache(maxsize=1)
     def get_master_port(self) -> int:
         if self.is_torch_run:
-            return int(os.environ.get("MASTER_PORT", "29500"))
+            return int(os.environ["MASTER_PORT"])
         rng = random.Random(int(os.environ.get("SLURM_JOB_ID", -1)))
         return rng.randint(MIN_MASTER_PORT, MAX_MASTER_PORT)
 
     @lru_cache(maxsize=1)
     def get_master_addr(self) -> str:
         if self.is_torch_run:
-            return os.environ.get("MASTER_ADDR", "127.0.0.1")
+            return os.environ["MASTER_ADDR"]
         if self.is_slurm_job:
-            try:
-                slurm_job_nodelist = os.environ.get("SLURM_JOB_NODELIST")
-                if slurm_job_nodelist:
-                    hostnames = subprocess.check_output(
-                        ["scontrol", "show", "hostnames", slurm_job_nodelist],
-                    )
-                    return hostnames.split()[0].decode("utf-8")
-            except (subprocess.CalledProcessError, KeyError, IndexError):
-                pass
+            hostnames = subprocess.check_output(
+                ["scontrol", "show", "hostnames", os.environ["SLURM_JOB_NODELIST"]],
+            )
+            return hostnames.split()[0].decode("utf-8")
         return "127.0.0.1"

--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -16,7 +16,6 @@ _job: Optional[JobInfo] = None
 
 
 def get_job() -> JobInfo:
-    """Get JobInfo instance, initializing on first call."""
     global _job
     if _job is None:
         _job = JobInfo()

--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -3,14 +3,24 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Dict, Literal, Tuple
+from typing import Dict, Literal, Optional, Tuple
 
 from clusterscope.cluster_info import LocalNodeInfo, UnifiedInfo
 from clusterscope.job_info import JobInfo
 
 unified_info = UnifiedInfo()
 local_info = LocalNodeInfo()
-job = JobInfo()
+
+# init only if clusterscope is queried for job info
+_job: Optional[JobInfo] = None
+
+
+def get_job() -> JobInfo:
+    """Get JobInfo instance, initializing on first call."""
+    global _job
+    if _job is None:
+        _job = JobInfo()
+    return _job
 
 
 def cluster() -> str:


### PR DESCRIPTION
## Summary

fixing issue https://github.com/facebookresearch/clusterscope/issues/56: clusterscope v0.0.11 breaks when env variables are not defined by setting default values to env variables

# test plan

```shell
$ python
Python 3.12.10 (main, May 17 2025, 13:50:06) [Clang 20.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import clusterscope
>>> clusterscope.get_job()
<clusterscope.job_info.JobInfo object at 0x7f99e8b11b20>
```