### PR TITLE
Add support for get_task_resource_requirements() API to enable inferring non-GPU resources for sub-node tasks

### DIFF
--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -197,7 +197,7 @@ class UnifiedInfo:
         total_gpus = sum(gpu_counts.values())
         return max(total_gpus, 1)  # Ensure at least 1 to avoid division by zero
 
-    def getTaskResourceRequirements(
+    def get_task_resource_requirements(
         self, num_gpus: int, num_tasks_per_node: int = 1
     ) -> ResourceShape:
         """Calculate resource requirements for better GPU packing based on node's GPU configuration.
@@ -206,7 +206,7 @@ class UnifiedInfo:
         For the maximum GPU count, returns all available node resources.
         Returns values in Slurm SBATCH format for direct use in job scripts.
 
-        NOTE: For array jobs, use getArrayJobRequirements() instead, which provides
+        NOTE: For array jobs, use get_array_job_requirements() instead, which provides
         per-array-element resource allocation.
 
         Args:
@@ -270,7 +270,7 @@ class UnifiedInfo:
             tasks_per_node=num_tasks_per_node,
         )
 
-    def getArrayJobRequirements(self, num_gpus_per_task: int) -> ResourceShape:
+    def get_array_job_requirements(self, num_gpus_per_task: int) -> ResourceShape:
         """Calculate resource requirements for array jobs with optimal GPU packing.
 
         For array jobs, each array element gets its own resource allocation.

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -4,15 +4,25 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import logging
+import math
 import os
 import platform
 import shutil
 import subprocess
 from collections import defaultdict
 from functools import lru_cache
-from typing import Dict, List, Set, Union
+from typing import Dict, List, NamedTuple, Set, Union
 
 from clusterscope.cache import fs_cache
+
+
+class ResourceShape(NamedTuple):
+    """Represents resource requirements for a job in Slurm SBATCH format."""
+
+    cpu_cores: int
+    memory: str
+    tasks_per_node: int
+
 
 # Common NVIDIA GPU types
 NVIDIA_GPU_TYPES = {
@@ -171,6 +181,156 @@ class UnifiedInfo:
             str: 'nvidia', 'amd', or 'none'
         """
         return self.local_node_info.get_gpu_vendor()
+
+    def get_total_gpus_per_node(self) -> int:
+        """Get the total number of GPUs available per node.
+
+        Returns:
+            int: Total number of GPUs per node. Returns 8 as default if no GPUs are detected.
+        """
+        gpu_counts = self.get_gpu_generation_and_count()
+        if not gpu_counts:
+            # Default to 8 if no GPUs detected (common configuration)
+            return 8
+
+        # Sum all GPU counts across different types
+        total_gpus = sum(gpu_counts.values())
+        return max(total_gpus, 1)  # Ensure at least 1 to avoid division by zero
+
+    def getTaskResourceRequirements(
+        self, num_gpus: int, num_tasks_per_node: int = 1
+    ) -> ResourceShape:
+        """Calculate resource requirements for better GPU packing based on node's GPU configuration.
+
+        Uses proportional allocation of node resources per GPU based on the node's total GPU count.
+        For the maximum GPU count, returns all available node resources.
+        Returns values in Slurm SBATCH format for direct use in job scripts.
+
+        NOTE: For array jobs, use getArrayJobRequirements() instead, which provides
+        per-array-element resource allocation.
+
+        Args:
+            num_gpus (int): Total number of GPUs required per node (1 to max available)
+            num_tasks_per_node (int): Number of tasks to run per node (default: 1)
+
+        Returns:
+            ResourceShape: Tuple containing CPU cores per task (int), memory per node (str),
+                          and tasks per node (int) in Slurm format
+                          e.g., ResourceShape(cpu_cores=24, memory="225G", tasks_per_node=1)
+
+        Raises:
+            ValueError: If num_gpus is not between 1 and max available GPUs, or if num_tasks_per_node < 1
+        """
+        # Get the total number of GPUs available per node
+        max_gpus_per_node = self.get_total_gpus_per_node()
+
+        if not (1 <= num_gpus <= max_gpus_per_node):
+            raise ValueError(f"num_gpus must be between 1 and {max_gpus_per_node}")
+
+        if num_tasks_per_node < 1:
+            raise ValueError("num_tasks_per_node must be at least 1")
+
+        # Get total resources per node
+        total_cpu_cores = self.get_cpus_per_node()
+        total_ram_mb = self.get_mem_per_node_MB()
+
+        if num_gpus == max_gpus_per_node:
+            # For max GPUs, use all available resources
+            total_required_cpu_cores = total_cpu_cores
+            total_required_ram_mb = total_ram_mb
+        else:
+            # Calculate per-GPU allocation based on actual GPU count per node
+            cpu_cores_per_gpu = total_cpu_cores / max_gpus_per_node
+            ram_mb_per_gpu = total_ram_mb / max_gpus_per_node
+
+            # Calculate total requirements for the requested number of GPUs
+            total_required_cpu_cores = math.ceil(cpu_cores_per_gpu * num_gpus)
+            total_required_ram_mb = math.ceil(ram_mb_per_gpu * num_gpus)
+
+        # Calculate per-task CPU allocation
+        cpu_cores_per_task = total_required_cpu_cores / num_tasks_per_node
+
+        # Convert to Slurm SBATCH format
+        # CPU cores per task: Round up to ensure we don't under-allocate
+        sbatch_cpu_cores = math.ceil(cpu_cores_per_task)
+
+        # Memory per node: Convert MB to GB and format for Slurm
+        # Note: Memory is allocated per node, not per task in most Slurm configurations
+        required_ram_gb = total_required_ram_mb / 1024
+        if required_ram_gb >= 1024:
+            # Use TB format for very large memory
+            sbatch_memory = f"{required_ram_gb / 1024:.0f}T"
+        else:
+            # Use GB format (most common)
+            sbatch_memory = f"{required_ram_gb:.0f}G"
+
+        return ResourceShape(
+            cpu_cores=sbatch_cpu_cores,
+            memory=sbatch_memory,
+            tasks_per_node=num_tasks_per_node,
+        )
+
+    def getArrayJobRequirements(self, num_gpus_per_task: int) -> ResourceShape:
+        """Calculate resource requirements for array jobs with optimal GPU packing.
+
+        For array jobs, each array element gets its own resource allocation.
+        This method calculates per-array-element resources based on proportional
+        allocation of node resources per GPU. For maximum GPUs, returns all
+        available node resources.
+
+        Args:
+            num_gpus_per_task (int): Number of GPUs required per array task (1 to max available)
+
+        Returns:
+            ResourceShape: Tuple containing CPU cores per array element (int),
+                          memory per array element (str), and tasks_per_node=1
+                          e.g., ResourceShape(cpu_cores=24, memory="225G", tasks_per_node=1)
+
+        Raises:
+            ValueError: If num_gpus_per_task is not between 1 and max available GPUs
+        """
+        # Get the total number of GPUs available per node
+        max_gpus_per_node = self.get_total_gpus_per_node()
+
+        if not (1 <= num_gpus_per_task <= max_gpus_per_node):
+            raise ValueError(
+                f"num_gpus_per_task must be between 1 and {max_gpus_per_node}"
+            )
+
+        # Get total resources per node
+        total_cpu_cores = self.get_cpus_per_node()
+        total_ram_mb = self.get_mem_per_node_MB()
+
+        if num_gpus_per_task == max_gpus_per_node:
+            # For max GPUs, use all available resources
+            required_cpu_cores = total_cpu_cores
+            required_ram_mb = total_ram_mb
+        else:
+            # Calculate per-GPU allocation based on actual GPU count per node
+            cpu_cores_per_gpu = total_cpu_cores / max_gpus_per_node
+            ram_mb_per_gpu = total_ram_mb / max_gpus_per_node
+
+            # Calculate requirements per array element
+            required_cpu_cores = math.ceil(cpu_cores_per_gpu * num_gpus_per_task)
+            required_ram_mb = math.ceil(ram_mb_per_gpu * num_gpus_per_task)
+
+        # Convert to Slurm SBATCH format
+        # CPU cores: Round up to ensure we don't under-allocate
+        sbatch_cpu_cores = math.ceil(required_cpu_cores)
+
+        # Memory: Convert MB to GB and format for Slurm
+        required_ram_gb = required_ram_mb / 1024
+        if required_ram_gb >= 1024:
+            # Use TB format for very large memory
+            sbatch_memory = f"{required_ram_gb / 1024:.0f}T"
+        else:
+            # Use GB format (most common)
+            sbatch_memory = f"{required_ram_gb:.0f}G"
+
+        # Array jobs always have 1 task per array element
+        return ResourceShape(
+            cpu_cores=sbatch_cpu_cores, memory=sbatch_memory, tasks_per_node=1
+        )
 
 
 class DarwinInfo:

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -606,7 +606,7 @@ class TestAWSClusterInfo(unittest.TestCase):
 
 
 class TestResourceRequirementMethods(unittest.TestCase):
-    """Test cases for getTaskResourceRequirements and getArrayJobRequirements methods."""
+    """Test cases for get_task_resource_requirements and get_array_job_requirements methods."""
 
     def setUp(self):
         self.unified_info = UnifiedInfo()
@@ -614,15 +614,15 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_total_gpus_per_node")
     @patch.object(UnifiedInfo, "get_cpus_per_node")
     @patch.object(UnifiedInfo, "get_mem_per_node_MB")
-    def test_getTaskResourceRequirements_single_gpu_8gpu_node(
+    def test_get_task_resource_requirements_single_gpu_8gpu_node(
         self, mock_mem, mock_cpus, mock_total_gpus
     ):
-        """Test getTaskResourceRequirements with 1 GPU on an 8-GPU node."""
+        """Test get_task_resource_requirements with 1 GPU on an 8-GPU node."""
         mock_total_gpus.return_value = 8
         mock_cpus.return_value = 192
         mock_mem.return_value = 1843200  # 1.8TB in MB
 
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=1)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=1)
 
         self.assertEqual(result.cpu_cores, 24)  # 192/8 = 24
         self.assertEqual(result.memory, "225G")  # 1843200/8/1024 = 225GB
@@ -631,15 +631,15 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_total_gpus_per_node")
     @patch.object(UnifiedInfo, "get_cpus_per_node")
     @patch.object(UnifiedInfo, "get_mem_per_node_MB")
-    def test_getTaskResourceRequirements_four_gpus_8gpu_node(
+    def test_get_task_resource_requirements_four_gpus_8gpu_node(
         self, mock_mem, mock_cpus, mock_total_gpus
     ):
-        """Test getTaskResourceRequirements with 4 GPUs on an 8-GPU node."""
+        """Test get_task_resource_requirements with 4 GPUs on an 8-GPU node."""
         mock_total_gpus.return_value = 8
         mock_cpus.return_value = 192
         mock_mem.return_value = 1843200
 
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=4)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=4)
 
         self.assertEqual(result.cpu_cores, 96)  # 192/8*4 = 96
         self.assertEqual(result.memory, "900G")  # 1843200/8*4/1024 = 900GB
@@ -648,15 +648,15 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_total_gpus_per_node")
     @patch.object(UnifiedInfo, "get_cpus_per_node")
     @patch.object(UnifiedInfo, "get_mem_per_node_MB")
-    def test_getTaskResourceRequirements_full_node_8gpu(
+    def test_get_task_resource_requirements_full_node_8gpu(
         self, mock_mem, mock_cpus, mock_total_gpus
     ):
-        """Test getTaskResourceRequirements with all 8 GPUs (full node)."""
+        """Test get_task_resource_requirements with all 8 GPUs (full node)."""
         mock_total_gpus.return_value = 8
         mock_cpus.return_value = 192
         mock_mem.return_value = 1843200
 
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=8)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=8)
 
         self.assertEqual(result.cpu_cores, 192)  # All CPUs
         self.assertEqual(
@@ -667,21 +667,21 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_total_gpus_per_node")
     @patch.object(UnifiedInfo, "get_cpus_per_node")
     @patch.object(UnifiedInfo, "get_mem_per_node_MB")
-    def test_getTaskResourceRequirements_4gpu_node_configuration(
+    def test_get_task_resource_requirements_4gpu_node_configuration(
         self, mock_mem, mock_cpus, mock_total_gpus
     ):
-        """Test getTaskResourceRequirements on a 4-GPU node configuration."""
+        """Test get_task_resource_requirements on a 4-GPU node configuration."""
         mock_total_gpus.return_value = 4
         mock_cpus.return_value = 64
         mock_mem.return_value = 524288  # 512GB in MB
 
         # Test 1 GPU on 4-GPU node
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=1)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=1)
         self.assertEqual(result.cpu_cores, 16)  # 64/4 = 16
         self.assertEqual(result.memory, "128G")  # 524288/4/1024 = 128GB
 
         # Test full 4-GPU node
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=4)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=4)
         self.assertEqual(result.cpu_cores, 64)  # All CPUs
         self.assertEqual(result.memory, "512G")  # All memory
 
@@ -696,7 +696,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
         mock_cpus.return_value = 192
         mock_mem.return_value = 1843200
 
-        result = self.unified_info.getTaskResourceRequirements(
+        result = self.unified_info.get_task_resource_requirements(
             num_gpus=4, num_tasks_per_node=2
         )
 
@@ -707,30 +707,30 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_total_gpus_per_node")
     @patch.object(UnifiedInfo, "get_cpus_per_node")
     @patch.object(UnifiedInfo, "get_mem_per_node_MB")
-    def test_getTaskResourceRequirements_memory_terabyte_format(
+    def test_get_task_resource_requirements_memory_terabyte_format(
         self, mock_mem, mock_cpus, mock_total_gpus
     ):
-        """Test getTaskResourceRequirements returns TB format for very large memory."""
+        """Test get_task_resource_requirements returns TB format for very large memory."""
         mock_total_gpus.return_value = 8
         mock_cpus.return_value = 192
         mock_mem.return_value = 8388608  # 8TB in MB
 
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=8)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=8)
 
         self.assertEqual(result.memory, "8T")  # 8388608/1024/1024 = 8TB
 
     @patch.object(UnifiedInfo, "get_total_gpus_per_node")
     @patch.object(UnifiedInfo, "get_cpus_per_node")
     @patch.object(UnifiedInfo, "get_mem_per_node_MB")
-    def test_getTaskResourceRequirements_cpu_rounding_up(
+    def test_get_task_resource_requirements_cpu_rounding_up(
         self, mock_mem, mock_cpus, mock_total_gpus
     ):
-        """Test getTaskResourceRequirements rounds up CPU cores when fractional."""
+        """Test get_task_resource_requirements rounds up CPU cores when fractional."""
         mock_total_gpus.return_value = 8
         mock_cpus.return_value = 191  # Odd number that doesn't divide evenly
         mock_mem.return_value = 1843200
 
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=1)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=1)
 
         # 191/8 = 23.875, should round up to 24
         self.assertEqual(result.cpu_cores, 24)
@@ -742,12 +742,12 @@ class TestResourceRequirementMethods(unittest.TestCase):
 
         # Test zero GPUs
         with self.assertRaises(ValueError) as context:
-            self.unified_info.getTaskResourceRequirements(num_gpus=0)
+            self.unified_info.get_task_resource_requirements(num_gpus=0)
         self.assertIn("num_gpus must be between 1 and 8", str(context.exception))
 
         # Test more than max GPUs
         with self.assertRaises(ValueError) as context:
-            self.unified_info.getTaskResourceRequirements(num_gpus=9)
+            self.unified_info.get_task_resource_requirements(num_gpus=9)
         self.assertIn("num_gpus must be between 1 and 8", str(context.exception))
 
     @patch.object(UnifiedInfo, "get_total_gpus_per_node")
@@ -756,7 +756,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
         mock_total_gpus.return_value = 8
 
         with self.assertRaises(ValueError) as context:
-            self.unified_info.getTaskResourceRequirements(
+            self.unified_info.get_task_resource_requirements(
                 num_gpus=1, num_tasks_per_node=0
             )
         self.assertIn("num_tasks_per_node must be at least 1", str(context.exception))
@@ -772,7 +772,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
         mock_cpus.return_value = 192
         mock_mem.return_value = 1843200
 
-        result = self.unified_info.getArrayJobRequirements(num_gpus_per_task=1)
+        result = self.unified_info.get_array_job_requirements(num_gpus_per_task=1)
 
         self.assertEqual(result.cpu_cores, 24)  # 192/8 = 24
         self.assertEqual(result.memory, "225G")  # 1843200/8/1024 = 225GB
@@ -789,7 +789,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
         mock_cpus.return_value = 192
         mock_mem.return_value = 1843200
 
-        result = self.unified_info.getArrayJobRequirements(num_gpus_per_task=4)
+        result = self.unified_info.get_array_job_requirements(num_gpus_per_task=4)
 
         self.assertEqual(result.cpu_cores, 96)  # 192/8*4 = 96
         self.assertEqual(result.memory, "900G")  # 1843200/8*4/1024 = 900GB
@@ -806,7 +806,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
         mock_cpus.return_value = 192
         mock_mem.return_value = 1843200
 
-        result = self.unified_info.getArrayJobRequirements(num_gpus_per_task=8)
+        result = self.unified_info.get_array_job_requirements(num_gpus_per_task=8)
 
         self.assertEqual(result.cpu_cores, 192)  # All CPUs
         self.assertEqual(
@@ -825,7 +825,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
         mock_cpus.return_value = 64
         mock_mem.return_value = 524288
 
-        result = self.unified_info.getArrayJobRequirements(num_gpus_per_task=2)
+        result = self.unified_info.get_array_job_requirements(num_gpus_per_task=2)
 
         self.assertEqual(result.cpu_cores, 32)  # 64/4*2 = 32
         self.assertEqual(result.memory, "256G")  # 524288/4*2/1024 = 256GB
@@ -838,14 +838,14 @@ class TestResourceRequirementMethods(unittest.TestCase):
 
         # Test zero GPUs
         with self.assertRaises(ValueError) as context:
-            self.unified_info.getArrayJobRequirements(num_gpus_per_task=0)
+            self.unified_info.get_array_job_requirements(num_gpus_per_task=0)
         self.assertIn(
             "num_gpus_per_task must be between 1 and 8", str(context.exception)
         )
 
         # Test more than max GPUs
         with self.assertRaises(ValueError) as context:
-            self.unified_info.getArrayJobRequirements(num_gpus_per_task=9)
+            self.unified_info.get_array_job_requirements(num_gpus_per_task=9)
         self.assertIn(
             "num_gpus_per_task must be between 1 and 8", str(context.exception)
         )
@@ -895,27 +895,27 @@ class TestResourceRequirementMethods(unittest.TestCase):
         mock_mem.return_value = 524288
 
         # Valid requests for 4-GPU node
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=1)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=1)
         self.assertIsInstance(result, ResourceShape)
 
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=4)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=4)
         self.assertIsInstance(result, ResourceShape)
 
         # Invalid request (more than available)
         with self.assertRaises(ValueError) as context:
-            self.unified_info.getTaskResourceRequirements(num_gpus=5)
+            self.unified_info.get_task_resource_requirements(num_gpus=5)
         self.assertIn("num_gpus must be between 1 and 4", str(context.exception))
 
         # Test with 16-GPU node
         mock_total_gpus.return_value = 16
 
         # Should now accept up to 16 GPUs
-        result = self.unified_info.getTaskResourceRequirements(num_gpus=16)
+        result = self.unified_info.get_task_resource_requirements(num_gpus=16)
         self.assertIsInstance(result, ResourceShape)
 
         # But not 17
         with self.assertRaises(ValueError) as context:
-            self.unified_info.getTaskResourceRequirements(num_gpus=17)
+            self.unified_info.get_task_resource_requirements(num_gpus=17)
         self.assertIn("num_gpus must be between 1 and 16", str(context.exception))
 
     def test_resource_shape_namedtuple(self):


### PR DESCRIPTION
## Summary

Given the large fraction of sub-node jobs running in Slurm clusters, users need to know how to shape their jobs for optimal packing on nodes with multiple GPUs.

As the users don't always have an idea, they tend to submit suboptimal job shapes. We can fill information gap by adding an API to ClusterScope to provide ideal sub-node task shape. If a given user's tasks cannot work in this shape, they could always override with required resources. However, for those that can fit, let's make the defaults easy.

Similarly, we have an array-job-requirements API. Perhaps the two could be merged.

## Test Plan

Unit tests
