### PR TITLE
Fix existing permissions

### DIFF
--- a/clusterscope/cache.py
+++ b/clusterscope/cache.py
@@ -6,6 +6,7 @@
 import ast
 import fcntl
 import functools
+import logging
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, Hashable, Union
@@ -39,6 +40,9 @@ def save(
         fd = os.open(filepath, os.O_WRONLY | os.O_APPEND)
     except PermissionError:
         # Can't open the file due to permission error, ignore caching instead of failing
+        logging.debug(
+            f"PermissionError when trying to open {filepath=}, won't cache results"
+        )
         return
     f = os.fdopen(fd, "a")
 

--- a/clusterscope/cache.py
+++ b/clusterscope/cache.py
@@ -26,6 +26,13 @@ def save(
         finally:
             os.umask(old_umask)
 
+    # Ensure file has permissions for all users to read/write
+    try:
+        os.chmod(filepath, 0o666)
+    except PermissionError:
+        # Try to write anyway and let it fail with a better error
+        pass
+
     loaded = load(filepath)
 
     fd = os.open(filepath, os.O_WRONLY | os.O_APPEND)

--- a/clusterscope/cache.py
+++ b/clusterscope/cache.py
@@ -35,7 +35,11 @@ def save(
 
     loaded = load(filepath)
 
-    fd = os.open(filepath, os.O_WRONLY | os.O_APPEND)
+    try:
+        fd = os.open(filepath, os.O_WRONLY | os.O_APPEND)
+    except PermissionError:
+        # Can't open the file due to permission error, ignore caching instead of failing
+        return
     f = os.fdopen(fd, "a")
 
     try:


### PR DESCRIPTION
## Summary

when the cache file already exists in the system it may have the old permissions (664). This PR moves existing files to 666 before attempting to save changes to the file (iff the user who created the file is the one running `cscope`) otherwise it ignores caching as it has no permission to edit the file.

## test plan

before
```
$ cscope job-gen task --num-gpus 7 --partition learn
PermissionError...
```

after
```
$ cscope job-gen task --num-gpus 7 --partition learn
{
  "cpu_cores": 168,
...
}
```