### PR TITLE
new api for job-gen [1/n]

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -174,7 +174,7 @@ def job_gen():
 
 @job_gen.group(name="task")
 def task():
-    """Generate job requirements for a task job."""
+    """Generate job requirements for a task of a job."""
     pass
 
 


### PR DESCRIPTION
## Summary

updating job-gen api to specify slurm and adding required arguments for slurm (partition)

## Test Plan

```
$ cscope job-gen task slurm --help
Usage: cscope job-gen task slurm [OPTIONS]

  Generate job requirements for a task job using Slurm.

Options:
  --num-gpus INTEGER              Number of GPUs to request  [required]
  --partition TEXT                Partition to query  [required]
  --num-tasks-per-node INTEGER    Number of tasks per node to request
  --format [json|sbatch|srun|submitit]
                                  Format to output the job requirements in
  --help                          Show this message and exit.
```
