### PR TITLE
removing default for partition arg

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -181,9 +181,7 @@ def task():
 
 @task.command()
 @click.option("--num-gpus", type=int, required=True, help="Number of GPUs to request")
-@click.option(
-    "--partition", type=str, default=None, required=True, help="Partition to query"
-)
+@click.option("--partition", type=str, required=True, help="Partition to query")
 @click.option(
     "--num-tasks-per-node",
     type=int,


### PR DESCRIPTION
## Summary

removing `default=None` for slurm partition on job-gen, so that it errors out with `Error: Missing option '--partition'.` when partition is not provided
