### PR TITLE
rejecting CLI requests if requesting for more GPUs than what the partition has available [4/n]

### DIFF
--- a/clusterscope/slurm/parser.py
+++ b/clusterscope/slurm/parser.py
@@ -1,18 +1,6 @@
 import re
 
 
-def extract_gpus_from_gres(gres_string: str) -> int:
-    """Extract the number of gpus from the GRES resources string"""
-    gpus = 0
-    gres_items = gres_string.split(",")
-    for gres in gres_items:
-        # If a gpu resource has been found.
-        if gres.startswith("gpu:"):
-            gpus = parse_gres(gres)
-
-    return gpus
-
-
 def parse_gres(gres_str: str) -> int:
     """Parse GPU count from GRES string.
 

--- a/clusterscope/slurm/parser.py
+++ b/clusterscope/slurm/parser.py
@@ -1,0 +1,33 @@
+import re
+
+
+def extract_gpus_from_gres(gres_string: str) -> int:
+    """Extract the number of gpus from the GRES resources string"""
+    gpus = 0
+    gres_items = gres_string.split(",")
+    for gres in gres_items:
+        # If a gpu resource has been found.
+        if gres.startswith("gpu:"):
+            gpus = parse_gres(gres)
+
+    return gpus
+
+
+def parse_gres(gres_str: str) -> int:
+    """Parse GPU count from GRES string.
+
+    Handles formats like:
+    - 'gpu:4'
+    - 'gpu:a100:2'
+    - 'gpu:volta:8(S:0-1)'
+    - 'gpu:pascal:2'
+    - '(null)'
+    """
+    if not gres_str or gres_str == "(null)":
+        return 0
+
+    match = re.search(r"gpu(?::\w+)?:(\d+)", gres_str)
+    if match:
+        return int(match.group(1))
+
+    return 0

--- a/clusterscope/slurm/partition.py
+++ b/clusterscope/slurm/partition.py
@@ -4,9 +4,11 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
+import subprocess
 from dataclasses import dataclass
 
 from clusterscope.shell import run_cli
+from clusterscope.slurm.parser import extract_gpus_from_gres
 
 
 @dataclass
@@ -14,6 +16,39 @@ class PartitionInfo:
     """Store partition information from scontrol."""
 
     name: str
+    max_gpus_per_node: int
+
+
+def get_node_resources(node_spec: str) -> dict:
+    """
+    Query node resources for given node specification.
+    Returns dict with max resources across nodes in the spec.
+    """
+    # not checking the return code here because `scontrol show node` can return non-zero exit code even
+    # though stdout has what we need.
+    result = subprocess.run(
+        ["scontrol", "show", "node", node_spec, "-o"], capture_output=True, text=True
+    )
+
+    max_gpus = 0
+
+    for line in result.stdout.strip().split("\n"):
+        if not line:
+            continue
+
+        node_data = {}
+        for item in line.split():
+            if "=" in item:
+                key, value = item.split("=", 1)
+                node_data[key] = value
+
+        gres = node_data.get("Gres", "")
+        gpu_count = extract_gpus_from_gres(gres)
+        max_gpus = max(max_gpus, gpu_count)
+
+    return {
+        "max_gpus": max_gpus,
+    }
 
 
 def get_partition_info() -> list[PartitionInfo]:
@@ -22,6 +57,8 @@ def get_partition_info() -> list[PartitionInfo]:
     Returns a list of PartitionInfo objects.
     """
     result = run_cli(["scontrol", "show", "partition", "-o"])
+
+    max_gpus = 0
 
     partitions = []
     for line in result.strip().split("\n"):
@@ -34,11 +71,19 @@ def get_partition_info() -> list[PartitionInfo]:
                 key, value = item.split("=", 1)
                 partition_data[key] = value
 
-        # Extract partition name
         name = partition_data.get("PartitionName", "Unknown")
+
+        nodes = partition_data.get("Nodes", "")
+        if nodes and nodes != "(null)":
+            node_info = get_node_resources(nodes)
+        else:
+            node_info = {
+                "max_gpus": 0,
+            }
 
         partition = PartitionInfo(
             name=name,
+            max_gpus_per_node=node_info["max_gpus"],
         )
         partitions.append(partition)
 

--- a/clusterscope/slurm/partition.py
+++ b/clusterscope/slurm/partition.py
@@ -4,11 +4,10 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-import subprocess
 from dataclasses import dataclass
 
 from clusterscope.shell import run_cli
-from clusterscope.slurm.parser import extract_gpus_from_gres
+from clusterscope.slurm.parser import parse_gres
 
 
 @dataclass
@@ -20,7 +19,7 @@ class PartitionInfo:
 
 
 def get_partition_resources(partition: str) -> dict:
-    result = subprocess.run(
+    result = run_cli(
         [
             "sinfo",
             "-o",
@@ -28,15 +27,12 @@ def get_partition_resources(partition: str) -> dict:
             f"--partition={partition}",
             "--noheader",
         ],
-        capture_output=True,
-        text=True,
-        check=True,
     )
 
-    stdout = result.stdout.strip().split("\n")[0]
+    stdout = result.strip().split("\n")[0]
 
     return {
-        "max_gpus": extract_gpus_from_gres(stdout),
+        "max_gpus": parse_gres(stdout),
     }
 
 


### PR DESCRIPTION
## Summary

rejecting CLI requests if requesting for more GPUs than what the partition has available

## Test Plan

observe requesting gpus on cpu partition raises value error:
```
$ cscope job-gen task slurm --num-gpus=4 --partition=cpu --format=sbatch --ti
me="1234234" --qos='learn' --slurm-cmd='python my.python.training'
...
ValueError: Requested 4 GPUs exceeds the maximum 0 GPUs per node available in partition 'cpu'
```
