### PR TITLE
adding method to format output to salloc

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -191,7 +191,7 @@ def task():
 @click.option(
     "--format",
     "output_format",
-    type=click.Choice(["json", "sbatch", "srun", "submitit"]),
+    type=click.Choice(["json", "sbatch", "srun", "submitit", "salloc"]),
     default="json",
     help="Format to output the job requirements in",
 )
@@ -218,6 +218,7 @@ def slurm(num_gpus: int, num_tasks_per_node: int, output_format: str, partition:
         "sbatch": job_requirements.to_sbatch,
         "srun": job_requirements.to_srun,
         "submitit": job_requirements.to_submitit,
+        "salloc": job_requirements.to_salloc,
     }
     click.echo(format_methods[output_format]())
 
@@ -229,7 +230,7 @@ def slurm(num_gpus: int, num_tasks_per_node: int, output_format: str, partition:
 @click.option(
     "--format",
     "output_format",
-    type=click.Choice(["json", "sbatch", "srun", "submitit"]),
+    type=click.Choice(["json", "sbatch", "srun", "submitit", "salloc"]),
     default="json",
     help="Format to output the job requirements in",
 )
@@ -252,6 +253,7 @@ def array(num_gpus_per_task: int, output_format: str, partition: str):
         "json": job_requirements.to_json,
         "sbatch": job_requirements.to_sbatch,
         "srun": job_requirements.to_srun,
+        "salloc": job_requirements.to_salloc,
         "submitit": job_requirements.to_submitit,
     }
     click.echo(format_methods[output_format]())

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -78,6 +78,22 @@ class ResourceShape(NamedTuple):
         ]
         return " ".join(cmd_parts)
 
+    def to_salloc(self) -> str:
+        """Convert ResourceShape to salloc command format.
+
+        Returns:
+            str: salloc command with resource specifications
+        """
+        cmd_parts = [
+            "salloc",
+            f"--cpus-per-task={self.cpu_cores}",
+            f"--mem={self.memory}",
+            f"--ntasks-per-node={self.tasks_per_node}",
+            f"--gres=gpu:{self.gpus_per_node}",
+            f"--partition={self.slurm_partition}",
+        ]
+        return " ".join(cmd_parts)
+
     def to_submitit(self) -> str:
         """Convert ResourceShape to submitit parameters format.
 


### PR DESCRIPTION
## Summary

converting job gen output to salloc

## Test Plan

```
$ cscope job-gen task slurm --partition=h100 --num-gpus=2 --format=salloc
salloc --cpus-per-task=48 --mem=499G --ntasks-per-node=1 --gres=gpu:2 --partition=h100
$ salloc --cpus-per-task=48 --mem=499G --ntasks-per-node=1 --gres=gpu:2 --partition=h100
# gets allocation
```
