### PR TITLE
adding tests for slurm job gen request validator

### DIFF
--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -100,8 +100,8 @@ def local_node_gpu_generation_and_count() -> Dict[str, int]:
 
 def job_gen_task_slurm(
     partition: str,
-    gpus_per_task: int = 0,
-    cpus_per_task: int = 0,
+    gpus_per_task: Optional[int] = None,
+    cpus_per_task: Optional[int] = None,
     tasks_per_node: int = 1,
 ) -> dict:
     """Get the number of CPUs/RAM for each task in the job."""

--- a/clusterscope/validate.py
+++ b/clusterscope/validate.py
@@ -24,22 +24,7 @@ def job_gen_task_slurm_validator(
             logging.error("Either gpus_per_task or cpus_per_task must be specified.")
             sys.exit(1)
         raise ValueError("Either gpus_per_task or cpus_per_task must be specified.")
-    if cpus_per_task and cpus_per_task < 0:
-        if exit_on_error:
-            logging.error("cpus_per_task has to be >= 0.")
-            sys.exit(1)
-        raise ValueError("cpus_per_task has to be >= 0.")
-    if gpus_per_task and gpus_per_task < 0:
-        if exit_on_error:
-            logging.error("gpus_per_task has to be >= 0.")
-            sys.exit(1)
-        raise ValueError("gpus_per_task has to be >= 0.")
-    if gpus_per_task == 0 and cpus_per_task == 0:
-        if exit_on_error:
-            logging.error("One of gpus_per_task or cpus_per_task has to be non-zero.")
-            sys.exit(1)
-        raise ValueError("One of gpus_per_task or cpus_per_task has to be non-zero.")
-    if gpus_per_task and cpus_per_task:
+    if gpus_per_task is not None and cpus_per_task is not None:
         if exit_on_error:
             logging.error(
                 "Only one of gpus_per_task or cpus_per_task can be specified. For GPU requests, use gpus_per_task and cpus_per_task will be generated automatically. For CPU requests, use cpus_per_task only."
@@ -48,6 +33,16 @@ def job_gen_task_slurm_validator(
         raise ValueError(
             "Only one of gpus_per_task or cpus_per_task can be specified. For GPU requests, use gpus_per_task and cpus_per_task will be generated automatically. For CPU requests, use cpus_per_task only."
         )
+    if cpus_per_task is not None and cpus_per_task <= 0:
+        if exit_on_error:
+            logging.error("cpus_per_task has to be > 0.")
+            sys.exit(1)
+        raise ValueError("cpus_per_task has to be > 0.")
+    if gpus_per_task is not None and gpus_per_task <= 0:
+        if exit_on_error:
+            logging.error("gpus_per_task has to be > 0.")
+            sys.exit(1)
+        raise ValueError("gpus_per_task has to be > 0.")
 
     partitions = get_partition_info()
     req_partition = next((p for p in partitions if p.name == partition), None)

--- a/clusterscope/validate.py
+++ b/clusterscope/validate.py
@@ -7,9 +7,9 @@ from clusterscope.slurm.partition import get_partition_info
 
 def job_gen_task_slurm_validator(
     partition: str,
-    gpus_per_task: Optional[int],
-    cpus_per_task: Optional[int],
-    tasks_per_node: int,
+    tasks_per_node: int = 1,
+    gpus_per_task: Optional[int] = None,
+    cpus_per_task: Optional[int] = None,
     exit_on_error: bool = False,
 ) -> None:
     """Validate the job requirements for a task of a Slurm job based on GPU or CPU per task requirements.
@@ -43,6 +43,11 @@ def job_gen_task_slurm_validator(
             logging.error("gpus_per_task has to be > 0.")
             sys.exit(1)
         raise ValueError("gpus_per_task has to be > 0.")
+    if tasks_per_node <= 0:
+        if exit_on_error:
+            logging.error("tasks_per_node has to be > 0.")
+            sys.exit(1)
+        raise ValueError("tasks_per_node has to be > 0.")
 
     partitions = get_partition_info()
     req_partition = next((p for p in partitions if p.name == partition), None)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,143 @@
+import shutil
+import unittest
+
+from unittest.mock import patch
+
+from clusterscope.slurm.partition import PartitionInfo
+from clusterscope.validate import job_gen_task_slurm_validator
+
+
+def has_slurm():
+    """Check if Slurm is installed."""
+    return shutil.which("scontrol") is not None
+
+
+class TestValidator(unittest.TestCase):
+
+    def test_job_gen_task_slurm_validator_no_args(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(partition="test-partition")
+
+    def test_job_gen_task_slurm_validator_cpu_and_gpu(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                gpus_per_task=1,
+                cpus_per_task=24,
+            )
+
+    def test_job_gen_task_slurm_validator_0_gpus(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                gpus_per_task=0,
+            )
+
+    def test_job_gen_task_slurm_validator_negative_gpus(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                gpus_per_task=-1,
+            )
+
+    def test_job_gen_task_slurm_validator_0_cpus(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                cpus_per_task=0,
+            )
+
+    def test_job_gen_task_slurm_validator_negative_cpus(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                cpus_per_task=-1,
+            )
+
+    def test_job_gen_task_slurm_validator_0_tasks_per_node(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                tasks_per_node=0,
+            )
+
+    def test_job_gen_task_slurm_validator_negative_tasks_per_node(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                tasks_per_node=-1,
+            )
+
+    @unittest.skipIf(not has_slurm(), "Slurm not available")
+    def test_job_gen_task_slurm_validator_non_existent_partition(self):
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="non-existent",
+                cpus_per_task=1,
+            )
+
+    @patch("clusterscope.validate.get_partition_info")
+    def test_job_gen_task_slurm_validator_valid_cpu(self, mock_run):
+        mock_run.return_value = [
+            PartitionInfo(
+                name="test-partition",
+                max_cpus_per_node=10,
+                max_gpus_per_node=10,
+            )
+        ]
+
+        job_gen_task_slurm_validator(
+            partition="test-partition",
+            cpus_per_task=5,
+            tasks_per_node=2,
+        )
+
+    @patch("clusterscope.validate.get_partition_info")
+    def test_job_gen_task_slurm_validator_valid_gpu(self, mock_run):
+        mock_run.return_value = [
+            PartitionInfo(
+                name="test-partition",
+                max_cpus_per_node=10,
+                max_gpus_per_node=10,
+            )
+        ]
+
+        job_gen_task_slurm_validator(
+            partition="test-partition",
+            gpus_per_task=5,
+            tasks_per_node=2,
+        )
+
+    @patch("clusterscope.validate.get_partition_info")
+    def test_job_gen_task_slurm_validator_invalid_cpu(self, mock_run):
+        mock_run.return_value = [
+            PartitionInfo(
+                name="test-partition",
+                max_cpus_per_node=10,
+                max_gpus_per_node=10,
+            )
+        ]
+
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                cpus_per_task=11,
+                tasks_per_node=1,
+            )
+
+    @patch("clusterscope.validate.get_partition_info")
+    def test_job_gen_task_slurm_validator_invalid_gpu(self, mock_run):
+        mock_run.return_value = [
+            PartitionInfo(
+                name="test-partition",
+                max_cpus_per_node=10,
+                max_gpus_per_node=10,
+            )
+        ]
+
+        with self.assertRaises(ValueError):
+            job_gen_task_slurm_validator(
+                partition="test-partition",
+                gpus_per_task=11,
+                tasks_per_node=1,
+            )


### PR DESCRIPTION
## Summary

adding tests for slurm validation function

## Test Plan

```
>>> import clusterscope
>>> clusterscope.job_gen_task_slurm(partition='h100', cpus_per_task=192)
{'cpus_per_task': 192, 'memory': '1999G', 'tasks_per_node': 1, 'slurm_partition': 'h100', 'mem_gb': 1999}
>>> clusterscope.job_gen_task_slurm(partition='h100', cpus_per_task=193)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/storage/home/luccab/clusterscope/clusterscope/lib.py", line 108, in job_gen_task_slurm
    job_gen_task_slurm_validator(
  File "/storage/home/luccab/clusterscope/clusterscope/validate.py", line 89, in job_gen_task_slurm_validator
    raise ValueError(
ValueError: Requested cpus_per_task=193 CPUs with tasks_per_node=1 exceeds the maximum 192 CPUs per node available in partition 'h100'
>>> clusterscope.job_gen_task_slurm(partition='h100', cpus_per_task=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/storage/home/luccab/clusterscope/clusterscope/lib.py", line 108, in job_gen_task_slurm
    job_gen_task_slurm_validator(
  File "/storage/home/luccab/clusterscope/clusterscope/validate.py", line 40, in job_gen_task_slurm_validator
    raise ValueError("cpus_per_task has to be > 0.")
ValueError: cpus_per_task has to be > 0.
>>> clusterscope.job_gen_task_slurm(partition='h100', gpus_per_task=0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/storage/home/luccab/clusterscope/clusterscope/lib.py", line 108, in job_gen_task_slurm
    job_gen_task_slurm_validator(
  File "/storage/home/luccab/clusterscope/clusterscope/validate.py", line 45, in job_gen_task_slurm_validator
    raise ValueError("gpus_per_task has to be > 0.")
ValueError: gpus_per_task has to be > 0.
>>> clusterscope.job_gen_task_slurm(partition='h100', gpus_per_task=9)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/storage/home/luccab/clusterscope/clusterscope/lib.py", line 108, in job_gen_task_slurm
    job_gen_task_slurm_validator(
  File "/storage/home/luccab/clusterscope/clusterscope/validate.py", line 75, in job_gen_task_slurm_validator
    raise ValueError(
ValueError: Requested gpus_per_task=9 GPUs with tasks_per_node=1 exceeds the maximum 8 GPUs per node available in partition 'h100'
>>> clusterscope.job_gen_task_slurm(partition='h100', gpus_per_task=8)
{'cpus_per_task': 192, 'memory': '1999G', 'tasks_per_node': 1, 'slurm_partition': 'h100', 'gpus_per_task': 8, 'mem_gb': 1999}
>>> clusterscope.job_gen_task_slurm(partition='h100', gpus_per_task=4)
{'cpus_per_task': 96, 'memory': '999G', 'tasks_per_node': 1, 'slurm_partition': 'h100', 'gpus_per_task': 4, 'mem_gb': 999}
>>> clusterscope.job_gen_task_slurm(partition='h100', gpus_per_task=4, cpus_per_task=192)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/storage/home/luccab/clusterscope/clusterscope/lib.py", line 108, in job_gen_task_slurm
    job_gen_task_slurm_validator(
  File "/storage/home/luccab/clusterscope/clusterscope/validate.py", line 33, in job_gen_task_slurm_validator
    raise ValueError(
ValueError: Only one of gpus_per_task or cpus_per_task can be specified. For GPU requests, use gpus_per_task and cpus_per_task will be generated automatically. For CPU requests, use cpus_per_task only.
```
