### PR TITLE
adding slurm cli and slurm_directives options to the cli -format

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -240,9 +240,9 @@ def slurm(
     format_methods = {
         "json": job_requirements.to_json,
         "sbatch": job_requirements.to_sbatch,
-        "srun": job_requirements.to_srun,
+        "slurm_directives": job_requirements.to_sbatch,
+        "slurm_cli": job_requirements.to_srun,
         "submitit": job_requirements.to_submitit,
-        "salloc": job_requirements.to_salloc,
     }
     click.echo(format_methods[output_format]())
 

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -50,7 +50,6 @@ class ResourceShape(NamedTuple):
             str: SBATCH script with resource directives
         """
         lines = [
-            "#!/bin/bash",
             f"#SBATCH --cpus-per-task={self.cpus_per_task}",
             f"#SBATCH --mem={self.memory}",
             f"#SBATCH --ntasks-per-node={self.tasks_per_node}",
@@ -67,24 +66,6 @@ class ResourceShape(NamedTuple):
             str: srun command with resource specifications
         """
         cmd_parts = [
-            "srun",
-            f"--cpus-per-task={self.cpus_per_task}",
-            f"--mem={self.memory}",
-            f"--ntasks-per-node={self.tasks_per_node}",
-            f"--partition={self.slurm_partition}",
-        ]
-        if self.gpus_per_task and self.gpus_per_task > 0:
-            cmd_parts.append(f"--gpus-per-task={self.gpus_per_task}")
-        return " ".join(cmd_parts)
-
-    def to_salloc(self) -> str:
-        """Convert ResourceShape to salloc command format.
-
-        Returns:
-            str: salloc command with resource specifications
-        """
-        cmd_parts = [
-            "salloc",
             f"--cpus-per-task={self.cpus_per_task}",
             f"--mem={self.memory}",
             f"--ntasks-per-node={self.tasks_per_node}",

--- a/tests/test_resource_shape.py
+++ b/tests/test_resource_shape.py
@@ -118,7 +118,6 @@ class TestResourceShape(unittest.TestCase):
                 result = resource.to_sbatch()
                 lines = result.split("\n")
 
-                self.assertEqual(lines[0], "#!/bin/bash")
                 sbatch_lines = [line for line in lines if line.startswith("#SBATCH")]
                 self.assertIn(f"#SBATCH --cpus-per-task={cpus_per_task}", result)
                 self.assertIn(f"#SBATCH --mem={memory}", result)
@@ -151,7 +150,6 @@ class TestResourceShape(unittest.TestCase):
                 result = resource.to_srun()
 
                 parts = result.split()
-                self.assertEqual(parts[0], "srun")
                 self.assertIn(f"--cpus-per-task={cpus_per_task}", result)
                 self.assertIn(f"--mem={memory}", result)
                 self.assertIn(f"--ntasks-per-node={tasks_per_node}", result)


### PR DESCRIPTION
## Summary

<!--
 Explain your changes. What existing problem does the pull request solve?

 If there's any open issue or discussions related to this PR, reference the issue here.
-->

## Test Plan

```
$ cscope job-gen task slurm --partition=h100 --gpus-per-task=4 --format=slurm_cli
--cpus-per-task=96 --mem=999G --ntasks-per-node=1 --partition=h100 --gpus-per-task=4
$ cscope job-gen task slurm --partition=h100 --gpus-per-task=4 --format=slurm_directives
#SBATCH --cpus-per-task=96
#SBATCH --mem=999G
#SBATCH --ntasks-per-node=1
#SBATCH --partition=h100
#SBATCH --gpus-per-task=4
```
