### PR TITLE
adding nodes passthrough arg [2/n]

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -189,6 +189,12 @@ def task():
     help="Number of tasks per node to request",
 )
 @click.option(
+    "--nodes",
+    type=int,
+    default=1,
+    help="Number nodes to request",
+)
+@click.option(
     "--format",
     "output_format",
     type=click.Choice(["json", "sbatch", "slurm_directives", "slurm_cli", "submitit"]),
@@ -214,6 +220,7 @@ def task():
 )
 def slurm(
     tasks_per_node: int,
+    nodes: int,
     output_format: str,
     partition: str,
     gpus_per_task: Optional[int],
@@ -234,6 +241,7 @@ def slurm(
         cpus_per_task=cpus_per_task,
         gpus_per_task=gpus_per_task,
         tasks_per_node=tasks_per_node,
+        nodes=nodes,
     )
 
     # Route to the correct format method based on CLI option

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -26,6 +26,7 @@ class ResourceShape(NamedTuple):
     memory: str
     tasks_per_node: int
     slurm_partition: str
+    nodes: int
     gpus_per_task: Optional[int] = None
 
     def to_dict(self) -> dict:
@@ -251,6 +252,7 @@ class UnifiedInfo:
         cpus_per_task: Optional[int] = None,
         gpus_per_task: Optional[int] = None,
         tasks_per_node: int = 1,
+        nodes: int = 1,
     ) -> ResourceShape:
         """Calculate resource requirements for better GPU packing based on node's GPU configuration.
 
@@ -320,6 +322,7 @@ class UnifiedInfo:
             gpus_per_task=gpus_per_task,
             memory=memory,
             tasks_per_node=tasks_per_node,
+            nodes=nodes,
         )
 
 

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -942,6 +942,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
             cpus_per_task=24,
             memory="225G",
             tasks_per_node=1,
+            nodes=1,
         )
 
         # Test that it's immutable (characteristic of NamedTuple)

--- a/tests/test_resource_shape.py
+++ b/tests/test_resource_shape.py
@@ -31,6 +31,7 @@ class TestResourceShape(unittest.TestCase):
             cpus_per_task=24,
             memory="225G",
             tasks_per_node=1,
+            nodes=1,
         )
 
         # Test immutability (NamedTuple characteristic)
@@ -61,6 +62,7 @@ class TestResourceShape(unittest.TestCase):
                     cpus_per_task=8,
                     memory=memory_str,
                     tasks_per_node=1,
+                    nodes=1,
                 )
                 self.assertEqual(parse_memory_to_gb(resource.memory), expected_gb)
 
@@ -84,6 +86,7 @@ class TestResourceShape(unittest.TestCase):
                     cpus_per_task=cpus_per_task,
                     memory=memory,
                     tasks_per_node=tasks_per_node,
+                    nodes=1,
                 )
                 result = json.loads(resource.to_json())
 
@@ -114,6 +117,7 @@ class TestResourceShape(unittest.TestCase):
                     cpus_per_task=cpus_per_task,
                     memory=memory,
                     tasks_per_node=tasks_per_node,
+                    nodes=1,
                 )
                 result = resource.to_sbatch()
                 lines = result.split("\n")
@@ -145,6 +149,7 @@ class TestResourceShape(unittest.TestCase):
                     cpus_per_task=cpus_per_task,
                     memory=memory,
                     tasks_per_node=tasks_per_node,
+                    nodes=1,
                 )
 
                 result = resource.to_srun()
@@ -176,6 +181,7 @@ class TestResourceShape(unittest.TestCase):
                     cpus_per_task=cpus_per_task,
                     memory=memory,
                     tasks_per_node=tasks_per_node,
+                    nodes=1,
                 )
                 result = json.loads(resource.to_submitit())
 


### PR DESCRIPTION
## Summary

taking nodes as input and outputting it for better support for array jobs

## Test Plan

```
$ cscope job-gen task slurm --partition=h100 --gpus-per-task=4
{
  "cpus_per_task": 96,
  "memory": "999G",
  "tasks_per_node": 1,
  "slurm_partition": "h100",
  "nodes": 1,
  "gpus_per_task": 4,
  "mem_gb": 999
}
$ cscope job-gen task slurm --partition=h100 --gpus-per-task=4 --nodes=4
{
  "cpus_per_task": 96,
  "memory": "999G",
  "tasks_per_node": 1,
  "slurm_partition": "h100",
  "nodes": 4,
  "gpus_per_task": 4,
  "mem_gb": 999
}
```
