### PR TITLE
Gpu to partitions

### DIFF
--- a/clusterscope/cli.py
+++ b/clusterscope/cli.py
@@ -101,34 +101,47 @@ def gpus(partition: str, generations: bool, counts: bool, vendor: bool):
     unified_info = UnifiedInfo(partition=partition)
 
     if vendor:
-        vendor_info = unified_info.get_gpu_vendor()
-        click.echo(f"Primary GPU vendor: {vendor_info}")
+        gpus = unified_info.get_gpu_generation_and_count()
+        all_vendors = set()
+        if gpus:
+            click.echo("GPU Vendors:")
+            for gpu in gpus:
+                if partition is not None and partition != gpu.partition:
+                    continue
+                if gpu.vendor in all_vendors:
+                    continue
+                all_vendors.add(gpu.vendor)
+                click.echo(f"- {gpu.vendor}")
     elif counts:
-        gpu_counts = unified_info.get_gpu_generation_and_count()
-        if gpu_counts:
-            click.echo("GPU counts by type:")
-            for gpu_type, count in sorted(gpu_counts.items()):
-                click.echo(f"  {gpu_type}: {count}")
+        gpus = unified_info.get_gpu_generation_and_count()
+        if gpus:
+            click.echo("GPU Gen, Count, Partition:")
+            for gpu in gpus:
+                if partition is not None and partition != gpu.partition:
+                    continue
+                click.echo(f"- {gpu.gpu_gen}, {gpu.gpu_count}, {gpu.partition}")
         else:
             click.echo("No GPUs found")
     elif generations:
-        gpu_counts = unified_info.get_gpu_generation_and_count()
-        if gpu_counts:
+        gpus = unified_info.get_gpu_generation_and_count()
+        if gpus:
             click.echo("GPU generations available:")
-            for gen in sorted(gpu_counts.keys()):
-                click.echo(f"- {gen}")
+            for gpu in gpus:
+                if partition is not None and partition != gpu.partition:
+                    continue
+                click.echo(f"- {gpu.gpu_gen}, {gpu.partition}")
         else:
             click.echo("No GPUs found")
     else:
-        # Default: show both vendor and detailed info
-        vendor_info = unified_info.get_gpu_vendor()
-        gpu_counts = unified_info.get_gpu_generation_and_count()
-
-        click.echo(f"GPU vendor: {vendor_info}")
-        if gpu_counts:
+        gpus = unified_info.get_gpu_generation_and_count()
+        if gpus:
             click.echo("GPU information:")
-            for gpu_type, count in sorted(gpu_counts.items()):
-                click.echo(f"  {gpu_type}: {count}")
+            for gpu in gpus:
+                if partition is not None and partition != gpu.partition:
+                    continue
+                click.echo(
+                    f"  partition: {gpu.partition}, gpu_gen: {gpu.gpu_gen}, count: {gpu.gpu_count}, vendor: {gpu.vendor}"
+                )
         else:
             click.echo("No GPUs found")
 

--- a/clusterscope/cluster_info.py
+++ b/clusterscope/cluster_info.py
@@ -119,6 +119,15 @@ class ResourceShape(NamedTuple):
         return json.dumps(params, indent=2)
 
 
+class GPUInfo(NamedTuple):
+    """Represents resource requirements for a job in Slurm SBATCH format."""
+
+    gpu_gen: str
+    gpu_count: int
+    vendor: str
+    partition: Optional[str] = None
+
+
 # Common NVIDIA GPU types
 NVIDIA_GPU_TYPES = {
     "A100": "A100",
@@ -215,7 +224,7 @@ class UnifiedInfo:
             return self.slurm_cluster_info.get_mem_per_node_MB()
         return self.local_node_info.get_mem_MB()
 
-    def get_gpu_generation_and_count(self) -> Dict[str, int]:
+    def get_gpu_generation_and_count(self) -> list[GPUInfo]:
         """Get the number of GPUs on the slurm cluster node.
 
         Returns:
@@ -225,7 +234,7 @@ class UnifiedInfo:
             return self.slurm_cluster_info.get_gpu_generation_and_count()
         if self.has_nvidia_gpus or self.has_amd_gpus:
             return self.local_node_info.get_gpu_generation_and_count()
-        return {}
+        return []
 
     def has_gpu_type(self, gpu_type: str) -> bool:
         """Check if a specific GPU type is available.
@@ -241,27 +250,19 @@ class UnifiedInfo:
         else:
             return self.local_node_info.has_gpu_type(gpu_type)
 
-    def get_gpu_vendor(self) -> str:
-        """Get the primary GPU vendor available on the system.
-
-        Returns:
-            str: 'nvidia', 'amd', or 'none'
-        """
-        return self.local_node_info.get_gpu_vendor()
-
     def get_total_gpus_per_node(self) -> int:
         """Get the total number of GPUs available per node.
 
         Returns:
             int: Total number of GPUs per node. Returns 8 as default if no GPUs are detected.
         """
-        gpu_counts = self.get_gpu_generation_and_count()
-        if not gpu_counts:
+        gpus = self.get_gpu_generation_and_count()
+        if not gpus:
             # Default to 8 if no GPUs detected (common configuration)
             return 8
 
         # Sum all GPU counts across different types
-        total_gpus = sum(gpu_counts.values())
+        total_gpus = sum([g.gpu_count for g in gpus])
         return max(total_gpus, 1)  # Ensure at least 1 to avoid division by zero
 
     def get_task_resource_requirements(
@@ -445,19 +446,6 @@ class LocalNodeInfo:
         except (FileNotFoundError, subprocess.CalledProcessError):
             return False
 
-    def get_gpu_vendor(self) -> str:
-        """Determine the primary GPU vendor on the system.
-
-        Returns:
-            str: 'nvidia', 'amd', or 'none'
-        """
-        if self.has_nvidia_gpus():
-            return "nvidia"
-        elif self.has_amd_gpus():
-            return "amd"
-        else:
-            return "none"
-
     def get_cpu_count(self, timeout: int = 60) -> int:
         """Get the number of CPUs on the local node.
 
@@ -493,12 +481,8 @@ class LocalNodeInfo:
         assert 0 < mem <= 10**12, f"Likely invalid memory: {mem}"
         return mem
 
-    def get_nvidia_gpu_info(self, timeout: int = 60) -> Dict[str, int]:
-        """Get NVIDIA GPU information using nvidia-smi.
-
-        Returns:
-            Dict[str, int]: Dictionary with GPU generation as keys and counts as values.
-        """
+    def get_nvidia_gpu_info(self, timeout: int = 60) -> GPUInfo:
+        """Get NVIDIA GPU information using nvidia-smi."""
         # Check if NVIDIA GPUs are available
         if not self.has_nvidia_gpus():
             try:
@@ -512,46 +496,48 @@ class LocalNodeInfo:
                 raise RuntimeError("No NVIDIA GPUs found")
         try:
             result = run_cli(
-                ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv,noheader"],
+                ["nvidia-smi", "--query-gpu=gpu_name,count", "--format=csv,noheader"],
                 text=True,
                 timeout=timeout,
             )
 
-            gpu_info: Dict[str, int] = defaultdict(int)
-            for line in result.strip().split("\n"):
-                if line.strip():
-                    # Extract GPU generation from full name
-                    # Examples: "NVIDIA A100-SXM4-40GB" -> "A100"
-                    #          "Tesla V100-SXM2-16GB" -> "V100"
-                    gpu_name_upper = line.strip().upper()
+            gpu_gen = ""
+            first_line = result.strip().split("\n")[0]
+            gpu_name_upper, count = first_line.split(", ")
+            gpu_name_upper = gpu_name_upper.strip().upper()
+            count_parsed = int(count)
 
-                    # Check for known NVIDIA GPU types
-                    found_gpu = False
-                    for gpu_key, gpu_pattern in NVIDIA_GPU_TYPES.items():
-                        if gpu_pattern in gpu_name_upper:
-                            gpu_info[gpu_key] += 1
-                            found_gpu = True
-                            break
+            # Check for known NVIDIA GPU types
+            found_gpu = False
+            for gpu_key, gpu_pattern in NVIDIA_GPU_TYPES.items():
+                if gpu_pattern in gpu_name_upper:
+                    gpu_gen = gpu_key
+                    found_gpu = True
+                    break
 
-                    # If no known GPU type was found
-                    if not found_gpu:
-                        # Generic fallback - try to extract model number
-                        words = gpu_name_upper.split()
-                        for word in words:
-                            if any(char.isdigit() for char in word) and len(word) > 2:
-                                gpu_info[word] += 1
-                                break
+            # If no known GPU type was found
+            if not found_gpu:
+                # Generic fallback - try to extract model number
+                words = gpu_name_upper.split()
+                for word in words:
+                    if any(char.isdigit() for char in word) and len(word) > 2:
+                        gpu_gen = word
+                        break
 
-            return gpu_info
+            # If no GPU generation was found, use the full name
+            if not found_gpu and gpu_gen == "":
+                gpu_gen = gpu_name_upper
+
+            return GPUInfo(
+                gpu_gen=gpu_gen,
+                gpu_count=count_parsed,
+                vendor="nvidia",
+            )
         except RuntimeError as e:
             raise RuntimeError(f"Failed to get NVIDIA GPU information: {str(e)}")
 
-    def get_amd_gpu_info(self, timeout: int = 60) -> Dict[str, int]:
-        """Get AMD GPU information using rocm-smi.
-
-        Returns:
-            Dict[str, int]: Dictionary with GPU generation as keys and counts as values.
-        """
+    def get_amd_gpu_info(self, timeout: int = 60) -> GPUInfo:
+        """Get AMD GPU information using rocm-smi."""
         # Check if AMD GPUs are available
         if not self.has_amd_gpus():
             try:
@@ -569,11 +555,13 @@ class LocalNodeInfo:
             )
 
             gpu_info: Dict[str, int] = defaultdict(int)
+            gpu_count = 0
             for line in result.strip().split("\n"):
                 if "GPU" in line and ":" in line:
                     # Parse lines like "GPU[0]: AMD Instinct MI300X"
                     parts = line.split(":")
                     if len(parts) >= 2:
+                        gpu_count += 1
                         gpu_name = parts[1].strip()
                         # Extract GPU generation from full name
                         # Examples: "AMD Instinct MI300X" -> "MI300X"
@@ -585,7 +573,7 @@ class LocalNodeInfo:
                         found_gpu = False
                         for gpu_key, gpu_pattern in AMD_GPU_TYPES.items():
                             if gpu_pattern in gpu_name_upper:
-                                gpu_info[gpu_key] += 1
+                                gpu_gen = gpu_key
                                 found_gpu = True
                                 break
 
@@ -598,14 +586,22 @@ class LocalNodeInfo:
                                     any(char.isdigit() for char in word)
                                     and len(word) > 2
                                 ):
-                                    gpu_info[word] += 1
+                                    gpu_gen = word
+                                    found_gpu = True
                                     break
 
-            return gpu_info
+                        if not found_gpu and gpu_gen is None:
+                            gpu_gen = gpu_name_upper
+
+            return GPUInfo(
+                gpu_gen=gpu_gen,
+                gpu_count=gpu_count,
+                vendor="amd",
+            )
         except RuntimeError as e:
             raise RuntimeError(f"Failed to get AMD GPU information: {str(e)}")
 
-    def get_gpu_generation_and_count(self, timeout: int = 60) -> Dict[str, int]:
+    def get_gpu_generation_and_count(self, timeout: int = 60) -> list[GPUInfo]:
         """Get GPU information for all available GPUs on the local node.
 
         Returns:
@@ -614,13 +610,13 @@ class LocalNodeInfo:
         Raises:
             RuntimeError: If unable to retrieve GPU information.
         """
-        gpu_info: Dict[str, int] = {}
+        gpu_info = []
 
         # Try NVIDIA GPUs
         if self.has_nvidia_gpus():
             try:
                 nvidia_info = self.get_nvidia_gpu_info(timeout)
-                gpu_info.update(nvidia_info)
+                gpu_info.append(nvidia_info)
             except RuntimeError as e:
                 logging.warning(f"Failed to get NVIDIA GPU info: {e}")
 
@@ -628,7 +624,7 @@ class LocalNodeInfo:
         if self.has_amd_gpus():
             try:
                 amd_info = self.get_amd_gpu_info(timeout)
-                gpu_info.update(amd_info)
+                gpu_info.append(amd_info)
             except RuntimeError as e:
                 logging.warning(f"Failed to get AMD GPU info: {e}")
 
@@ -648,8 +644,8 @@ class LocalNodeInfo:
             bool: True if the GPU type is available, False otherwise
         """
         try:
-            gpu_counts = self.get_gpu_generation_and_count()
-            return gpu_type.upper() in [k.upper() for k in gpu_counts.keys()]
+            gpus = self.get_gpu_generation_and_count()
+            return gpu_type.upper() in [g.gpu_gen for g in gpus]
         except RuntimeError:
             return False
 
@@ -772,6 +768,38 @@ class SlurmClusterInfo:
             logging.error(f"Failed to get Slurm memory information: {str(e)}")
             raise RuntimeError(f"Failed to get Slurm memory information: {str(e)}")
 
+    def get_cpus_per_partition(self) -> list[tuple[int, str]]:
+        """Get the minimum number of CPUs for each node in the cluster.
+
+        Returns:
+            int: The number of CPUs per node, assuming all nodes have the same CPU count.
+
+        Raises:
+            RuntimeError: If unable to retrieve node information or if nodes have different CPU counts.
+        """
+        try:
+            cmd = ["sinfo", "-o", "%100c,%100n", "--noheader"]
+
+            result = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            response = []
+
+            logging.debug("Parsing node information...")
+            for line in result.stdout.splitlines():
+                cpus, partition = line.split(",")
+                parsed_cpus = int(cpus.strip(" "))
+                partition = str(partition.strip("* "))
+                response.append((parsed_cpus, partition))
+            return response
+        except (subprocess.SubprocessError, FileNotFoundError) as e:
+            logging.error(f"Failed to get CPU information: {str(e)}")
+            raise RuntimeError(f"Failed to get CPU information: {str(e)}")
+
     def get_cpus_per_node(self) -> int:
         """Get the minimum number of CPUs for each node in the cluster.
 
@@ -803,7 +831,7 @@ class SlurmClusterInfo:
             logging.error(f"Failed to get CPU information: {str(e)}")
             raise RuntimeError(f"Failed to get CPU information: {str(e)}")
 
-    def get_gpu_generation_and_count(self) -> Dict[str, int]:
+    def get_gpu_generation_and_count(self) -> list[GPUInfo]:
         """
         Detects the GPU generation and count per server using `sinfo`.
 
@@ -812,7 +840,7 @@ class SlurmClusterInfo:
         """
         try:
             # Run sinfo command
-            cmd = ["sinfo", "-o", "%G"]
+            cmd = ["sinfo", "-o", "%G,%P"]
             if self.partition:
                 cmd.extend(["-p", self.partition])
 
@@ -824,17 +852,38 @@ class SlurmClusterInfo:
                 check=True,
             )
 
+            # (partition, gpu_gen, gpu_count)
+            results = []
+            all_partitions = set()
+
             # Parse output
-            gpu_info: Dict[str, int] = {}
             logging.debug("Parsing node information...")
             for line in result.stdout.splitlines():
-                parts = line.split(":")
-                if len(parts) >= 3:
-                    gpu_gen = parts[1]
-                    gpu_count = int(parts[2].split("(")[0])
-                    gpu_info[gpu_gen] = gpu_info.get(gpu_gen, 0) + gpu_count
+                gres, partition = line.split(",")
+                partition = partition.strip("* ")
+                if partition in all_partitions:
+                    continue
+                all_partitions.add(partition)
+                gres_parts = gres.split(":")
+                if len(gres_parts) >= 3:
+                    gpu_gen = gres_parts[1]
+                    gpu_count = int(gres_parts[2].split("(")[0])
+                    vendor = "Vendor Not Found"
+                    if gpu_gen.upper() in NVIDIA_GPU_TYPES:
+                        vendor = "nvidia"
+                    elif gpu_gen.upper() in AMD_GPU_TYPES:
+                        vendor = "amd"
 
-            return gpu_info
+                    results.append(
+                        GPUInfo(
+                            partition=partition,
+                            gpu_gen=gpu_gen,
+                            gpu_count=gpu_count,
+                            vendor=vendor,
+                        )
+                    )
+
+            return results
         except (subprocess.SubprocessError, FileNotFoundError) as e:
             logging.error(f"Failed to get GPU information: {str(e)}")
             raise RuntimeError(f"Failed to get GPU information: {str(e)}")
@@ -886,8 +935,8 @@ class SlurmClusterInfo:
         Returns:
             bool: True if the GPU type is available, False otherwise
         """
-        gpu_counts = self.get_gpu_generation_and_count()
-        return gpu_type.upper() in [k.upper() for k in gpu_counts.keys()]
+        gpus = self.get_gpu_generation_and_count()
+        return gpu_type.upper() in [g.gpu_gen for g in gpus]
 
     def get_max_job_lifetime(self) -> str:
         """Get the maximum job lifetime specified in the Slurm configuration.

--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -3,9 +3,9 @@
 
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Dict, Literal, Optional, Tuple
+from typing import Literal, Optional, Tuple
 
-from clusterscope.cluster_info import LocalNodeInfo, UnifiedInfo
+from clusterscope.cluster_info import GPUInfo, LocalNodeInfo, UnifiedInfo
 from clusterscope.job_info import JobInfo
 from clusterscope.validate import job_gen_task_slurm_validator
 
@@ -93,7 +93,7 @@ def get_tmp_dir():
     return tmp
 
 
-def local_node_gpu_generation_and_count() -> Dict[str, int]:
+def local_node_gpu_generation_and_count() -> list[GPUInfo]:
     """Get the GPU generation and count for the local node."""
     return local_info.get_gpu_generation_and_count()
 

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -565,21 +565,25 @@ GPU[3]: AMD Radeon RX 7900 XTX"""
         """Test get_gpu_generation_and_count with both NVIDIA and AMD GPUs."""
         mock_has_nvidia.return_value = True
         mock_has_amd.return_value = True
-        nvidia_return = GPUInfo(
-            gpu_count=2,
-            gpu_gen="A100",
-            vendor="nvidia",
-        )
+        nvidia_return = [
+            GPUInfo(
+                gpu_count=2,
+                gpu_gen="A100",
+                vendor="nvidia",
+            )
+        ]
         mock_nvidia_info.return_value = nvidia_return
-        amd_return = GPUInfo(
-            gpu_count=4,
-            gpu_gen="MI300X",
-            vendor="amd",
-        )
+        amd_return = [
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="MI300X",
+                vendor="amd",
+            )
+        ]
         mock_amd_info.return_value = amd_return
 
         result = self.local_node_info.get_gpu_generation_and_count()
-        expected = [nvidia_return, amd_return]
+        expected = nvidia_return + amd_return
         self.assertEqual(result, expected)
 
     @patch.object(LocalNodeInfo, "has_nvidia_gpus")

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -430,38 +430,6 @@ class TestLocalNodeInfo(unittest.TestCase):
         mock_run.side_effect = subprocess.CalledProcessError(1, ["rocm-smi"])
         self.assertFalse(self.local_node_info.has_amd_gpus())
 
-    @patch.object(LocalNodeInfo, "has_nvidia_gpus")
-    @patch.object(LocalNodeInfo, "has_amd_gpus")
-    def test_get_gpu_vendor_nvidia(self, mock_has_amd, mock_has_nvidia):
-        """Test get_gpu_vendor returns 'nvidia' when NVIDIA GPUs are present."""
-        mock_has_nvidia.return_value = True
-        mock_has_amd.return_value = False
-        self.assertEqual(self.local_node_info.get_gpu_vendor(), "nvidia")
-
-    @patch.object(LocalNodeInfo, "has_nvidia_gpus")
-    @patch.object(LocalNodeInfo, "has_amd_gpus")
-    def test_get_gpu_vendor_amd(self, mock_has_amd, mock_has_nvidia):
-        """Test get_gpu_vendor returns 'amd' when AMD GPUs are present."""
-        mock_has_nvidia.return_value = False
-        mock_has_amd.return_value = True
-        self.assertEqual(self.local_node_info.get_gpu_vendor(), "amd")
-
-    @patch.object(LocalNodeInfo, "has_nvidia_gpus")
-    @patch.object(LocalNodeInfo, "has_amd_gpus")
-    def test_get_gpu_vendor_none(self, mock_has_amd, mock_has_nvidia):
-        """Test get_gpu_vendor returns 'none' when no GPUs are present."""
-        mock_has_nvidia.return_value = False
-        mock_has_amd.return_value = False
-        self.assertEqual(self.local_node_info.get_gpu_vendor(), "none")
-
-    @patch.object(LocalNodeInfo, "has_nvidia_gpus")
-    @patch.object(LocalNodeInfo, "has_amd_gpus")
-    def test_get_gpu_vendor_nvidia_priority(self, mock_has_amd, mock_has_nvidia):
-        """Test get_gpu_vendor returns 'nvidia' when both GPU types are present (NVIDIA has priority)."""
-        mock_has_nvidia.return_value = True
-        mock_has_amd.return_value = True
-        self.assertEqual(self.local_node_info.get_gpu_vendor(), "nvidia")
-
     @patch("clusterscope.cluster_info.run_cli")
     def test_get_nvidia_gpu_info_success(self, mock_run_cli):
         """Test successful NVIDIA GPU information retrieval."""

--- a/tests/test_cluster_info.py
+++ b/tests/test_cluster_info.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from clusterscope.cluster_info import (
     AWSClusterInfo,
     DarwinInfo,
+    GPUInfo,
     LinuxInfo,
     LocalNodeInfo,
     ResourceShape,
@@ -36,7 +37,7 @@ class TestUnifiedInfo(unittest.TestCase):
         unified_info = UnifiedInfo()
         unified_info.is_slurm_cluster = False
         unified_info.has_nvidia_gpus = False
-        self.assertEqual(unified_info.get_gpu_generation_and_count(), {})
+        self.assertEqual(unified_info.get_gpu_generation_and_count(), [])
 
     def test_partition_passed_to_slurm_cluster_info(self):
         unified_info = UnifiedInfo(partition="test_partition")
@@ -81,11 +82,13 @@ class TestSlurmClusterInfo(unittest.TestCase):
         self.cluster_info_with_partition = SlurmClusterInfo(partition="test_partition")
 
     @patch("subprocess.run")
-    def test_get_cluster_name(self, mock_run):
+    @patch("clusterscope.cache.load")
+    def test_get_cluster_name(self, mock_cache, mock_run):
         # Mock successful cluster name retrieval
         mock_run.return_value = MagicMock(
             stdout="ClusterName=test_cluster\nOther=value", returncode=0
         )
+        mock_cache.return_value = {"SLURM_CLUSTER_NAME": "test_cluster"}
         self.assertEqual(self.cluster_info.get_cluster_name(), "test_cluster")
 
     @patch("subprocess.run")
@@ -224,17 +227,30 @@ class TestSlurmClusterInfo(unittest.TestCase):
     def test_get_gpu_generation_and_count_with_partition(self, mock_run):
         # Mock successful GPU generation and count retrieval with partition
         mock_run.return_value = MagicMock(
-            stdout="gpu:a100:4(S:0-1)\ngpu:v100:2(S:0)\n",
+            stdout="gpu:a100:4(S:0-1), test_partition\ngpu:v100:2(S:0), test_partition\n",
             returncode=0,
         )
 
         result = self.cluster_info_with_partition.get_gpu_generation_and_count()
-        expected = {"a100": 4, "v100": 2}
+        expected = [
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="a100",
+                vendor="nvidia",
+                partition="test_partition",
+            ),
+            GPUInfo(
+                gpu_count=2,
+                gpu_gen="v100",
+                vendor="nvidia",
+                partition="test_partition",
+            ),
+        ]
         self.assertEqual(result, expected)
 
         # Verify that partition argument was passed to subprocess.run
         mock_run.assert_called_with(
-            ["sinfo", "-o", "%G", "-p", "test_partition"],
+            ["sinfo", "-o", "%G,%P", "-p", "test_partition"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -259,7 +275,18 @@ class TestSlurmClusterInfo(unittest.TestCase):
     @patch("clusterscope.cluster_info.SlurmClusterInfo.get_gpu_generation_and_count")
     def test_has_gpu_type_true(self, mock_get_gpu_generation_and_count):
         # Set up the mock to return a dictionary with the GPU type we're looking for
-        mock_get_gpu_generation_and_count.return_value = {"A100": 4, "V100": 2}
+        mock_get_gpu_generation_and_count.return_value = [
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="A100",
+                vendor="nvidia",
+            ),
+            GPUInfo(
+                gpu_count=2,
+                gpu_gen="V100",
+                vendor="nvidia",
+            ),
+        ]
 
         # Create an instance of the class containing the has_gpu_type method
         gpu_manager = SlurmClusterInfo()
@@ -433,21 +460,27 @@ class TestLocalNodeInfo(unittest.TestCase):
     @patch("clusterscope.cluster_info.run_cli")
     def test_get_nvidia_gpu_info_success(self, mock_run_cli):
         """Test successful NVIDIA GPU information retrieval."""
-        mock_run_cli.return_value = (
-            "NVIDIA A100-SXM4-40GB\nNVIDIA A100-SXM4-40GB\nTesla V100-SXM2-16GB"
-        )
+        mock_run_cli.return_value = "NVIDIA A100-SXM4-40GB, 2\nNVIDIA A100-SXM4-40GB, 2\nTesla V100-SXM2-16GB, 1"
 
         result = self.local_node_info.get_nvidia_gpu_info()
-        expected = {"A100": 2, "V100": 1}
+        expected = [
+            GPUInfo(gpu_gen="A100", gpu_count=2, vendor="nvidia"),
+            GPUInfo(gpu_gen="V100", gpu_count=1, vendor="nvidia"),
+        ]
         self.assertEqual(result, expected)
 
     @patch("clusterscope.cluster_info.run_cli")
     def test_get_nvidia_gpu_info_empty_lines(self, mock_run_cli):
         """Test NVIDIA GPU info parsing with empty lines."""
-        mock_run_cli.return_value = "NVIDIA A100-SXM4-40GB\n\n\nTesla V100-SXM2-16GB\n"
+        mock_run_cli.return_value = (
+            "NVIDIA A100-SXM4-40GB, 1\n\n\nTesla V100-SXM2-16GB, 1\n"
+        )
 
         result = self.local_node_info.get_nvidia_gpu_info()
-        expected = {"A100": 1, "V100": 1}
+        expected = [
+            GPUInfo(gpu_gen="A100", gpu_count=1, vendor="nvidia"),
+            GPUInfo(gpu_gen="V100", gpu_count=1, vendor="nvidia"),
+        ]
         self.assertEqual(result, expected)
 
     @patch("clusterscope.cluster_info.run_cli")
@@ -457,7 +490,7 @@ class TestLocalNodeInfo(unittest.TestCase):
 GPU[1]: AMD Instinct MI300X"""
 
         result = self.local_node_info.get_amd_gpu_info()
-        expected = {"MI300X": 2}
+        expected = [GPUInfo(gpu_gen="MI300X", gpu_count=2, vendor="amd")]
         self.assertEqual(result, expected)
 
     @patch("clusterscope.cluster_info.run_cli")
@@ -466,7 +499,7 @@ GPU[1]: AMD Instinct MI300X"""
         mock_run_cli.return_value = "GPU[0]: AMD Instinct MI300A"
 
         result = self.local_node_info.get_amd_gpu_info()
-        expected = {"MI300A": 1}
+        expected = [GPUInfo(gpu_gen="MI300A", gpu_count=1, vendor="amd")]
         self.assertEqual(result, expected)
 
     @patch("clusterscope.cluster_info.run_cli")
@@ -478,8 +511,31 @@ GPU[2]: AMD Instinct MI100
 GPU[3]: AMD Radeon RX 7900 XTX"""
 
         result = self.local_node_info.get_amd_gpu_info()
-        expected = {"MI250X": 1, "MI210": 1, "MI100": 1, "RX7900XTX": 1}
-        self.assertEqual(result, expected)
+
+        expected = [
+            GPUInfo(
+                gpu_count=1,
+                gpu_gen="MI250X",
+                vendor="amd",
+            ),
+            GPUInfo(
+                gpu_count=1,
+                gpu_gen="MI210",
+                vendor="amd",
+            ),
+            GPUInfo(
+                gpu_count=1,
+                gpu_gen="MI100",
+                vendor="amd",
+            ),
+            GPUInfo(
+                gpu_count=1,
+                gpu_gen="RX7900XTX",
+                vendor="amd",
+            ),
+        ]
+        for gpu in expected:
+            self.assertIn(gpu, result)
 
     @patch("clusterscope.cluster_info.run_cli")
     def test_get_amd_gpu_info_generic_fallback(self, mock_run_cli):
@@ -488,7 +544,7 @@ GPU[3]: AMD Radeon RX 7900 XTX"""
 
         result = self.local_node_info.get_amd_gpu_info()
         # Should fall back to extracting "6800" as the model
-        expected = {"6800": 1}
+        expected = [GPUInfo(gpu_gen="6800", gpu_count=1, vendor="amd", partition=None)]
         self.assertEqual(result, expected)
 
     @patch("clusterscope.cluster_info.run_cli")
@@ -497,39 +553,7 @@ GPU[3]: AMD Radeon RX 7900 XTX"""
         mock_run_cli.return_value = "Some other output\nNo GPU information here"
 
         result = self.local_node_info.get_amd_gpu_info()
-        self.assertEqual(result, {})
-
-    @patch.object(LocalNodeInfo, "has_nvidia_gpus")
-    @patch.object(LocalNodeInfo, "has_amd_gpus")
-    @patch.object(LocalNodeInfo, "get_nvidia_gpu_info")
-    @patch.object(LocalNodeInfo, "get_amd_gpu_info")
-    def test_get_gpu_generation_and_count_nvidia_only(
-        self, mock_amd_info, mock_nvidia_info, mock_has_amd, mock_has_nvidia
-    ):
-        """Test get_gpu_generation_and_count with NVIDIA GPUs only."""
-        mock_has_nvidia.return_value = True
-        mock_has_amd.return_value = False
-        mock_nvidia_info.return_value = {"A100": 2, "V100": 1}
-
-        result = self.local_node_info.get_gpu_generation_and_count()
-        expected = {"A100": 2, "V100": 1}
-        self.assertEqual(result, expected)
-
-    @patch.object(LocalNodeInfo, "has_nvidia_gpus")
-    @patch.object(LocalNodeInfo, "has_amd_gpus")
-    @patch.object(LocalNodeInfo, "get_nvidia_gpu_info")
-    @patch.object(LocalNodeInfo, "get_amd_gpu_info")
-    def test_get_gpu_generation_and_count_amd_only(
-        self, mock_amd_info, mock_nvidia_info, mock_has_amd, mock_has_nvidia
-    ):
-        """Test get_gpu_generation_and_count with AMD GPUs only."""
-        mock_has_nvidia.return_value = False
-        mock_has_amd.return_value = True
-        mock_amd_info.return_value = {"MI300X": 4, "MI250X": 2}
-
-        result = self.local_node_info.get_gpu_generation_and_count()
-        expected = {"MI300X": 4, "MI250X": 2}
-        self.assertEqual(result, expected)
+        self.assertEqual(result, [])
 
     @patch.object(LocalNodeInfo, "has_nvidia_gpus")
     @patch.object(LocalNodeInfo, "has_amd_gpus")
@@ -541,11 +565,21 @@ GPU[3]: AMD Radeon RX 7900 XTX"""
         """Test get_gpu_generation_and_count with both NVIDIA and AMD GPUs."""
         mock_has_nvidia.return_value = True
         mock_has_amd.return_value = True
-        mock_nvidia_info.return_value = {"A100": 2}
-        mock_amd_info.return_value = {"MI300X": 4}
+        nvidia_return = GPUInfo(
+            gpu_count=2,
+            gpu_gen="A100",
+            vendor="nvidia",
+        )
+        mock_nvidia_info.return_value = nvidia_return
+        amd_return = GPUInfo(
+            gpu_count=4,
+            gpu_gen="MI300X",
+            vendor="amd",
+        )
+        mock_amd_info.return_value = amd_return
 
         result = self.local_node_info.get_gpu_generation_and_count()
-        expected = {"A100": 2, "MI300X": 4}
+        expected = [nvidia_return, amd_return]
         self.assertEqual(result, expected)
 
     @patch.object(LocalNodeInfo, "has_nvidia_gpus")
@@ -559,7 +593,7 @@ GPU[3]: AMD Radeon RX 7900 XTX"""
         mock_has_amd.return_value = False
 
         result = self.local_node_info.get_gpu_generation_and_count()
-        self.assertEqual(result, {})
+        self.assertEqual(result, [])
         mock_logging.assert_called_with(
             "No GPUs found or unable to retrieve GPU information"
         )
@@ -567,7 +601,18 @@ GPU[3]: AMD Radeon RX 7900 XTX"""
     @patch.object(LocalNodeInfo, "get_gpu_generation_and_count")
     def test_has_gpu_type_true(self, mock_get_gpu_info):
         """Test has_gpu_type returns True for available GPU types."""
-        mock_get_gpu_info.return_value = {"A100": 2, "MI300X": 4}
+        mock_get_gpu_info.return_value = [
+            GPUInfo(
+                gpu_count=2,
+                gpu_gen="A100",
+                vendor="nvidia",
+            ),
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="MI300X",
+                vendor="amd",
+            ),
+        ]
 
         self.assertTrue(self.local_node_info.has_gpu_type("A100"))
         self.assertTrue(self.local_node_info.has_gpu_type("MI300X"))
@@ -577,7 +622,18 @@ GPU[3]: AMD Radeon RX 7900 XTX"""
     @patch.object(LocalNodeInfo, "get_gpu_generation_and_count")
     def test_has_gpu_type_false(self, mock_get_gpu_info):
         """Test has_gpu_type returns False for unavailable GPU types."""
-        mock_get_gpu_info.return_value = {"A100": 2, "MI300X": 4}
+        mock_get_gpu_info.return_value = [
+            GPUInfo(
+                gpu_count=2,
+                gpu_gen="A100",
+                vendor="nvidia",
+            ),
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="MI300X",
+                vendor="amd",
+            ),
+        ]
 
         self.assertFalse(self.local_node_info.has_gpu_type("V100"))
         self.assertFalse(self.local_node_info.has_gpu_type("MI250X"))
@@ -596,15 +652,6 @@ class TestUnifiedInfoAMDSupport(unittest.TestCase):
 
     def setUp(self):
         self.unified_info = UnifiedInfo()
-
-    @patch.object(LocalNodeInfo, "get_gpu_vendor")
-    def test_get_gpu_vendor(self, mock_get_gpu_vendor):
-        """Test UnifiedInfo.get_gpu_vendor delegates to LocalNodeInfo."""
-        mock_get_gpu_vendor.return_value = "amd"
-
-        result = self.unified_info.get_gpu_vendor()
-        self.assertEqual(result, "amd")
-        mock_get_gpu_vendor.assert_called_once()
 
     @patch.object(LocalNodeInfo, "has_gpu_type")
     def test_has_gpu_type_local_node(self, mock_has_gpu_type):
@@ -873,7 +920,18 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_gpu_generation_and_count")
     def test_get_total_gpus_per_node_with_gpus(self, mock_gpu_info):
         """Test get_total_gpus_per_node with actual GPU detection."""
-        mock_gpu_info.return_value = {"A100": 4, "V100": 4}
+        mock_gpu_info.return_value = [
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="a100",
+                vendor="nvidia",
+            ),
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="v100",
+                vendor="nvidia",
+            ),
+        ]
 
         result = self.unified_info.get_total_gpus_per_node()
         self.assertEqual(result, 8)  # 4 + 4 = 8
@@ -881,7 +939,7 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_gpu_generation_and_count")
     def test_get_total_gpus_per_node_no_gpus_detected(self, mock_gpu_info):
         """Test get_total_gpus_per_node defaults to 8 when no GPUs detected."""
-        mock_gpu_info.return_value = {}
+        mock_gpu_info.return_value = []
 
         result = self.unified_info.get_total_gpus_per_node()
         self.assertEqual(result, 8)  # Default fallback
@@ -889,7 +947,13 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_gpu_generation_and_count")
     def test_get_total_gpus_per_node_single_gpu_type(self, mock_gpu_info):
         """Test get_total_gpus_per_node with single GPU type."""
-        mock_gpu_info.return_value = {"A100": 8}
+        mock_gpu_info.return_value = [
+            GPUInfo(
+                gpu_count=8,
+                gpu_gen="a100",
+                vendor="nvidia",
+            ),
+        ]
 
         result = self.unified_info.get_total_gpus_per_node()
         self.assertEqual(result, 8)
@@ -897,7 +961,23 @@ class TestResourceRequirementMethods(unittest.TestCase):
     @patch.object(UnifiedInfo, "get_gpu_generation_and_count")
     def test_get_total_gpus_per_node_mixed_gpu_types(self, mock_gpu_info):
         """Test get_total_gpus_per_node with mixed GPU types."""
-        mock_gpu_info.return_value = {"A100": 2, "V100": 4, "P100": 2}
+        mock_gpu_info.return_value = [
+            GPUInfo(
+                gpu_count=2,
+                gpu_gen="a100",
+                vendor="nvidia",
+            ),
+            GPUInfo(
+                gpu_count=4,
+                gpu_gen="v100",
+                vendor="nvidia",
+            ),
+            GPUInfo(
+                gpu_count=2,
+                gpu_gen="p100",
+                vendor="nvidia",
+            ),
+        ]
 
         result = self.unified_info.get_total_gpus_per_node()
         self.assertEqual(result, 8)  # 2 + 4 + 2 = 8


### PR DESCRIPTION
## Summary

adding `--partitions` to `cscope gpus` made a few of the commands either look broken or show partial information. This PR fixes all CMDs, look at the test plan to see examples after this change

## Test Plan

```
$ cscope gpus
GPU information:
  partition: h100, gpu_gen: h100, count: 8, vendor: nvidia
  partition: h100_admin_testing, gpu_gen: h100, count: 8, vendor: nvidia
  partition: h200, gpu_gen: h200, count: 8, vendor: nvidia
  partition: h200, gpu_gen: h200, count: 8, vendor: nvidia
  partition: h200_admin_testing, gpu_gen: h200, count: 8, vendor: nvidia
$ cscope gpus generations
Usage: cscope gpus [OPTIONS]
Try 'cscope gpus --help' for help.

Error: Got unexpected extra argument (generations)
$ cscope gpus
GPU information:
  partition: h100, gpu_gen: h100, count: 8, vendor: nvidia
  partition: h100_admin_testing, gpu_gen: h100, count: 8, vendor: nvidia
  partition: h200, gpu_gen: h200, count: 8, vendor: nvidia
  partition: h200, gpu_gen: h200, count: 8, vendor: nvidia
  partition: h200_admin_testing, gpu_gen: h200, count: 8, vendor: nvidia
$ cscope gpus --generations
GPU generations available:
- h100, h100
- h100, h100_admin_testing
- h200, h200
- h200, h200
- h200, h200_admin_testing
$ cscope gpus --counts
GPU Gen, Count, Partition:
- h100, 8, h100
- h100, 8, h100_admin_testing
- h200, 8, h200
- h200, 8, h200
- h200, 8, h200_admin_testing
$ cscope gpus --vendor
GPU Vendors:
- nvidia
$ cscope gpus --counts --partition=h100
GPU Gen, Count, Partition:
- h100, 8, h100
$ cscope check-gpu
Usage: cscope check-gpu [OPTIONS] GPU_TYPE
Try 'cscope check-gpu --help' for help.

Error: Missing argument 'GPU_TYPE'.
$ cscope check-gpu h100
GPU type h100 is available in the cluster.
$ cscope check-gpu h300
GPU type h300 is NOT available in the cluster.
$ cscope check-gpu h200
GPU type h200 is available in the cluster.
```
