### PR TITLE
exposing job cpus and gpus

### DIFF
--- a/clusterscope/job_info.py
+++ b/clusterscope/job_info.py
@@ -9,6 +9,8 @@ import subprocess
 
 from functools import lru_cache
 
+from clusterscope.cluster_info import LocalNodeInfo
+
 MIN_MASTER_PORT, MAX_MASTER_PORT = (20_000, 60_000)
 
 
@@ -39,6 +41,23 @@ class JobInfo:
         self.local_rank = self.get_local_rank()
         self.world_size = self.get_world_size()
         self.is_rank_zero = self.get_is_rank_zero()
+
+    @lru_cache(maxsize=1)
+    def get_cpus(self) -> int:
+        if self.is_slurm_job():
+            return int(os.environ.get("SLURM_CPUS_ON_NODE", 1))
+        return int(max(os.cpu_count() or 0, 1))
+
+    @lru_cache(maxsize=1)
+    def get_gpus(self) -> int:
+        if self.is_slurm_job():
+            return int(os.environ.get("SLURM_GPUS_ON_NODE", 1))
+        return sum(
+            [
+                int(count)
+                for gpu, count in LocalNodeInfo().get_gpu_generation_and_count().items()
+            ]
+        )
 
     @lru_cache(maxsize=1)
     def get_job_id(self) -> int:


### PR DESCRIPTION
## Summary

exposing a way to get number of cpus and gpus from job information. defaults to local host if not on a slurm cluster

## Test Plan

works on slurm and locally:
```
$ srun python -c "import clusterscope; print(clusterscope.get_job().get_gpus()
); print(clusterscope.get_job().get_cpus())"
...
srun: job 1476042 has been allocated resources
1
2
$ python
Python 3.12.4 | packaged by Anaconda, Inc. | (main, Jun 18 2024, 15:12:24) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import clusterscope
>>> clusterscope.get_job().get_gpus()
WARNING:root:No GPUs found or unable to retrieve GPU information
0
>>> clusterscope.get_job().get_cpus()
96
```
local node with gpus:
```
Type "help", "copyright", "credits" or "license" for more information.
>>> import clusterscope
>>> clusterscope.get_job().get_gpus()
2
>>> clusterscope.get_job().get_cpus()
80
>>> exit()
```
