### PR TITLE
[website] Add trailing slashes for links

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -29,6 +29,7 @@ const config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'facebookresearch', // Usually your GitHub org/user name.
   projectName: 'clusterscope', // Usually your repo name.
+  trailingSlash: true,
 
   onBrokenLinks: 'throw',
 


### PR DESCRIPTION
Caught this adding algolia - we're generating links without the trailing slash which is fine client side but with GitHub pages results in a redirect to the URL with a trailing slash in direct HTTP requests.
