### PR TITLE
Parse SchedMD pre-release / zero-padded Slurm versions robustly

### DIFF
--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -17,6 +17,7 @@ from clusterscope.validate import (
     job_gen_task_slurm_validator,
     validate_partition_exists,
 )
+from packaging.version import Version
 
 # Partition-aware unified info instance
 _unified_info: Optional[UnifiedInfo] = None
@@ -62,8 +63,14 @@ def slurm_version(partition: Optional[str] = None) -> Tuple[int, ...]:
         partition (str, optional): Slurm partition name to filter queries.
     """
     slurm_version = get_unified_info(partition).get_slurm_version()
-    version = tuple(int(v) for v in slurm_version.split("."))
-    return version
+    # SchedMD pre-release builds append a non-PEP440 "-<n>pre<n>" suffix to the
+    # micro (e.g. "26.05.2-0pre1"). Strip it, then let packaging normalize the
+    # numeric release (including the zero-padded YY.MM minor) into the int tuple
+    # that callers compare against. Fall back to the legacy split for odd forms.
+    try:
+        return Version(slurm_version.split("-", 1)[0]).release
+    except Exception:
+        return tuple(int(v) for v in slurm_version.split("."))
 
 
 def cpus(partition: Optional[str] = None) -> list[CPUInfo] | CPUInfo:

--- a/clusterscope/lib.py
+++ b/clusterscope/lib.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 from typing import Optional, Tuple
 
+from packaging.version import InvalidVersion, Version
+
 from clusterscope.cluster_info import (
     CPUInfo,
     GPUInfo,
@@ -17,7 +19,6 @@ from clusterscope.validate import (
     job_gen_task_slurm_validator,
     validate_partition_exists,
 )
-from packaging.version import Version
 
 # Partition-aware unified info instance
 _unified_info: Optional[UnifiedInfo] = None
@@ -66,10 +67,11 @@ def slurm_version(partition: Optional[str] = None) -> Tuple[int, ...]:
     # SchedMD pre-release builds append a non-PEP440 "-<n>pre<n>" suffix to the
     # micro (e.g. "26.05.2-0pre1"). Strip it, then let packaging normalize the
     # numeric release (including the zero-padded YY.MM minor) into the int tuple
-    # that callers compare against. Fall back to the legacy split for odd forms.
+    # that callers compare against. Fall back to the legacy split if packaging
+    # cannot parse it.
     try:
         return Version(slurm_version.split("-", 1)[0]).release
-    except Exception:
+    except InvalidVersion:
         return tuple(int(v) for v in slurm_version.split("."))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ authors = [
 dependencies = [
     "click>=8.0.0, !=8.3.0",
     "click-option-group",
+    "packaging",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

`slurm_version()` parsed the Slurm version with `tuple(int(v) for v in version.split("."))`, which assumes every dot-separated component is a plain integer. SchedMD pre-release builds append a `-<n>pre<n>` suffix to the micro version, so `sinfo -V` reports e.g. `slurm 26.05.2-0pre1` and `int("2-0pre1")` raises `ValueError: invalid literal for int() with base 10: '2-0pre1'`. This crashes every caller — for example gcm's `slurm_monitor` poller — on clusters running Slurm built from a SchedMD development branch rather than a tagged release.

Parse the numeric release with `packaging.version.Version` after stripping the non-PEP440 pre-release suffix. `packaging` also normalizes the zero-padded `YY.MM` minor (`26.05` -> `26`), which strict SemVer rejects outright. The `Tuple[int, ...]` return type is unchanged so existing comparisons (e.g. `slurm_version() >= (23, 2)`) keep working, and any unexpected string falls back to the original split. Adds `packaging` (pure-Python, already ubiquitous) to `dependencies`.

## Test Plan

Exercised the patched `slurm_version()` with the version string mocked to each SchedMD form — including the zero-padded pre-release the old `int()` split crashed on:

```
$ python -c "
from unittest.mock import patch
import clusterscope.lib as lib
for s in ['26.05.2-0pre1', '24.11.2-0pre1', '24.05.0', '25.11']:
    with patch.object(lib, 'get_unified_info') as m:
        m.return_value.get_slurm_version.return_value = s
        print(f'{s:16} -> {lib.slurm_version()}')
"
26.05.2-0pre1    -> (26, 5, 2)
24.11.2-0pre1    -> (24, 11, 2)
24.05.0          -> (24, 5, 0)
25.11            -> (25, 11)
```